### PR TITLE
fix: update schema $id fields to reflect schema/ subdirectory path

### DIFF
--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -1,7 +1,7 @@
 {
   "version": "0.6.0",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/DirectedEdges/anova/main/anova.schema.json",
+  "$id": "https://raw.githubusercontent.com/DirectedEdges/anova/main/schema/component.schema.json",
   "title": "Anova Plugin Output Schema",
   "description": "JSON Schema for data that's output by the Anova Figma plugin produced by Directed Edges",
   "$comment": "Copyright (c) 2025 Directed Edges. Licensed under CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/). Attribution required.",

--- a/schema/components.schema.json
+++ b/schema/components.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/DirectedEdges/anova/main/components.schema.json",
+  "$id": "https://raw.githubusercontent.com/DirectedEdges/anova/main/schema/components.schema.json",
   "title": "Anova Components Set Schema",
   "description": "A set of named components, each conforming to the Anova component schema.",
   "version": "0.6.0",

--- a/schema/root.schema.json
+++ b/schema/root.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/DirectedEdges/anova/main/root.schema.json",
+  "$id": "https://raw.githubusercontent.com/DirectedEdges/anova/main/schema/root.schema.json",
   "title": "Anova Schema Package",
   "description": "Root schema for the Anova component and components set definitions.",
   "version": "0.6.0",

--- a/schema/styles.schema.json
+++ b/schema/styles.schema.json
@@ -1,7 +1,7 @@
 {
   "version": "0.6.0",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/DirectedEdges/anova/main/styles.schema.json",
+  "$id": "https://raw.githubusercontent.com/DirectedEdges/anova/main/schema/styles.schema.json",
   "title": "Anova Styles Schema",
   "description": "JSON Schema for style properties emitted by the Anova Figma plugin",
   "$comment": "Copyright (c) 2025 Directed Edges. Licensed under CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/). Attribution required.",


### PR DESCRIPTION
## Summary

- The `$id` URIs in all four schema files were pointing to the repo root (e.g. `/main/styles.schema.json`) instead of the actual file locations under `schema/`
- Also corrects the component schema `$id` which was using the old filename `anova.schema.json` instead of `component.schema.json`

## Files changed

- `schema/component.schema.json`
- `schema/components.schema.json`
- `schema/root.schema.json`
- `schema/styles.schema.json`

## Test plan

- [ ] Verify each `$id` URL resolves correctly to the raw file on the `main` branch after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)