### PR TITLE
feat: add examples to TextProp and IconProp (ADR 014)

### DIFF
--- a/.github/agents/Anova.adr.create.agent.md
+++ b/.github/agents/Anova.adr.create.agent.md
@@ -31,7 +31,10 @@ You **MUST** consider the user input before proceeding (if not empty).
    - If the branch matches an ADR name pattern (e.g., `009-color-values`), determine the release branch by reading `package.json` version.
    - If the branch is `main` or doesn't match either pattern, fall back to reading `package.json` version and using the current minor version as `RELEASE_BRANCH`.
 
-   **Step 1b — Ask the user** using VS Code's interactive question UI. Present ALL questions in a single prompt:
+   **Step 1b — Sync release branch and determine next ADR number (silent, no user prompt)**
+   Run `git fetch origin $RELEASE_BRANCH` and fast-forward the local branch if behind (`git pull origin $RELEASE_BRANCH`). Then list `adr/` on the synced branch to find the highest existing ADR number and compute `NEXT_ADR_NUMBER` (zero-padded to 3 digits).
+
+   **Step 1c — Ask the user** using VS Code's interactive question UI. Present ALL questions in a single prompt:
 
    **Question 1 — Describe the change**
    - Header: `Change`
@@ -47,7 +50,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
    **Question 3 — ADR file name**
    - Header: `ADR file`
-   - Question: "What should the ADR file be named? This becomes `adr/[name].md` and the ADR branch `[name]`. Use the format `###-short-description` (e.g. `002-shadows`)."
+   - Question: "Next ADR number is `[NEXT_ADR_NUMBER]`. What should the ADR be named? This becomes `adr/[name].md` and the ADR branch `[name]`. Use the format `###-short-description` (e.g. `[NEXT_ADR_NUMBER]-shadows`)."
    - Allow free-form input. No predefined options.
 
    Parse answers as `CHANGE_DESCRIPTION`, `RELEASE_BRANCH`, and `ADR_NAME`.
@@ -55,7 +58,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 2. **Branch setup**:
    - Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root. Parse `REPO_ROOT`.
-   - Check that `$RELEASE_BRANCH` exists (locally or on origin). If not, ask whether to create it from `main`.
+   - Verify `$RELEASE_BRANCH` is synced with remote (already fetched and fast-forwarded in Step 1b).
    - If not already on `$ADR_BRANCH`, check if it exists — switch to it or create it from `$RELEASE_BRANCH`.
    - Set `SPEC_FILE=$REPO_ROOT/adr/$ADR_NAME.md`.
    - If `$SPEC_FILE` exists, read it and continue editing rather than overwriting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Metadata.generator.license` — optional resolved license state: `status` and `level` nested inside generator
 - `Styles.fillColor` — icon fill color for ICON element type
+- `TextProp.examples` — sample values demonstrating typical text content
+- `IconProp.examples` — sample values demonstrating typical icon content
 
 ### Changed
+
+- `TextProp.default` — now optional; use `examples` for demo content
+- `IconProp.default` — now optional; use `examples` for demo content
 
 ### Removed
 

--- a/adr/014-prop-examples.md
+++ b/adr/014-prop-examples.md
@@ -1,0 +1,185 @@
+# ADR: Add `examples` to `TextProp` and `IconProp`, deprecate `default`
+
+**Branch**: `014-prop-examples`
+**Created**: 2026-03-09
+**Status**: ACCEPTED
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+`TextProp` and `IconProp` each carry a required `default` field that stores a single string value (e.g., `"Label"` for text, `"Check"` for an icon). In practice, these values originate from Figma's `componentPropertyReferences` under `.default` and represent **demonstration content**, not a true semantic default that consumers should rely on.
+
+Treating demo content as `default` is misleading: downstream consumers may interpret it as the authoritative fallback value for rendering, when it is actually sample data intended to illustrate usage. The current shape provides no way to distinguish "this is a genuine default" from "this is just an example."
+
+JSON Schema's `examples` keyword (an array of values) is the established convention for expressing sample/demo data without implying it is a default.
+
+---
+
+## Decision Drivers
+
+- **Semantic accuracy**: The field name must correctly convey the role of the data — sample content is not a default
+- **Additive-only change**: Avoid a MAJOR bump; new fields should be optional to preserve backward compatibility during the transition
+- **Type ↔ Schema symmetry**: Every type change must have a corresponding schema change (Constitution I)
+- **No runtime logic**: This package must remain types and schema only (Constitution II)
+- **JSON Schema alignment**: Prefer standard JSON Schema conventions (`examples`) over custom vocabulary
+
+---
+
+## Options Considered
+
+### Option A: Add optional `examples` array, make `default` optional *(Selected)*
+
+Add an optional `examples: string[]` field to both `TextProp` and `IconProp`. Simultaneously make `default` optional (not required) so that producers can migrate to `examples` without a breaking change. During the transition period, both fields may coexist.
+
+**Pros**:
+- Follows the JSON Schema `examples` convention — familiar to consumers
+- Additive change: new optional field → MINOR bump
+- Making `default` optional (rather than removing it) preserves backward compatibility
+- Supports multiple example values, which is more expressive than a single default
+
+**Cons / Trade-offs**:
+- Temporary overlap: both `default` and `examples` may be present until a future MAJOR removes `default`
+- Consumers must handle the optional nature of `default` during the transition
+
+---
+
+### Option B: Rename `default` to `example` (singular) *(Rejected)*
+
+Replace `default` with a single `example: string` field.
+
+**Rejected because**: Renaming a required field is a breaking change (MAJOR bump). A singular field also does not accommodate multiple examples, limiting expressiveness. Breaks backward compatibility immediately with no transition path.
+
+---
+
+### Option C: Keep `default` and add a `isExample` boolean flag *(Rejected)*
+
+Add a boolean `isExample` flag to indicate when `default` is actually demo content.
+
+**Rejected because**: This works around the naming problem without solving it. The field is still called `default`, which remains semantically misleading. Adds a boolean to distinguish meaning rather than using the correct vocabulary. Does not align with JSON Schema conventions.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Props.ts` | Add optional `examples?: string[]` to `TextProp` | MINOR |
+| `Props.ts` | Make `default` optional on `TextProp` (`default?: string`) | MINOR |
+| `Props.ts` | Add optional `examples?: string[]` to `IconProp` | MINOR |
+| `Props.ts` | Make `default` optional on `IconProp` (`default?: string`) | MINOR |
+
+**Example — new shape** (`types/Props.ts`):
+```yaml
+# Before
+TextProp:
+  type: 'string'        # required
+  default: string        # required
+  nullable?: boolean
+
+IconProp:
+  type: 'string'        # required
+  default: string        # required
+  nullable?: boolean
+
+# After
+TextProp:
+  type: 'string'        # required
+  default?: string       # optional — MINOR (relaxed from required)
+  nullable?: boolean
+  examples?: string[]    # optional — MINOR
+
+IconProp:
+  type: 'string'        # required
+  default?: string       # optional — MINOR (relaxed from required)
+  nullable?: boolean
+  examples?: string[]    # optional — MINOR
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Add optional `examples` property (array of strings) to `TextProp` definition | MINOR |
+| `component.schema.json` | Remove `default` from `required` array in `TextProp` | MINOR |
+| `component.schema.json` | Add optional `examples` property (array of strings) to `IconProp` definition | MINOR |
+| `component.schema.json` | Remove `default` from `required` array in `IconProp` | MINOR |
+
+**Example — new shape** (`schema/component.schema.json`):
+```yaml
+# TextProp definition — properties
+type:
+  type: string
+  const: "string"
+default:
+  type: string
+nullable:
+  type: boolean
+examples:
+  type: array
+  items:
+    type: string
+  description: "Sample values demonstrating typical content for this prop"
+# required: ["type"] — "default" removed from required
+
+# IconProp definition — properties (same structure)
+type:
+  type: string
+  const: "string"
+default:
+  type: string
+nullable:
+  type: boolean
+examples:
+  type: array
+  items:
+    type: string
+  description: "Sample values demonstrating typical content for this prop"
+# required: ["type"] — "default" removed from required
+```
+
+### Notes
+
+- The `examples` property on the JSON Schema definitions is a **custom property** within the object definition (under `properties`), not the JSON Schema meta-keyword `examples` at the definition level. This avoids collision with the schema-level `examples` keyword already present on each definition.
+- `default` is made optional, not removed, to allow a deprecation period. A future MAJOR version can remove `default` from `TextProp` and `IconProp` entirely.
+- `BooleanProp`, `EnumProp`, and `SlotProp` are unaffected — their `default` fields carry genuine semantic defaults.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**:
+  - `TextProp.examples` (type) ↔ `#/definitions/TextProp/properties/examples` (schema)
+  - `TextProp.default` optional (type) ↔ `default` removed from `#/definitions/TextProp/required` (schema)
+  - `IconProp.examples` (type) ↔ `#/definitions/IconProp/properties/examples` (schema)
+  - `IconProp.default` optional (type) ↔ `default` removed from `#/definitions/IconProp/required` (schema)
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `anova-kit` | Recompile; `default` on `TextProp`/`IconProp` becomes possibly `undefined` | Update any code that reads `.default` without a null check; optionally begin reading `.examples` |
+
+---
+
+## Semver Decision
+
+**Version bump**: `MINOR`
+
+**Justification**: All changes are additive optional fields or relaxation of required constraints. No fields are removed or renamed. Per Constitution III: "MINOR for additive types or new optional fields."
+
+---
+
+## Consequences
+
+- Producers can populate `examples` with demo content instead of misusing `default`
+- Consumers must handle `default` being optional on `TextProp` and `IconProp` (it may be `undefined`)
+- A future MAJOR version can cleanly remove `default` from these two prop types once all producers have migrated to `examples`
+- `BooleanProp`, `EnumProp`, and `SlotProp` are unchanged — their `default` semantics remain correct

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -142,9 +142,14 @@
       "properties": {
         "type": { "type": "string", "const": "string" },
         "default": { "type": "string" },
-        "nullable": { "type": "boolean" }
+        "nullable": { "type": "boolean" },
+        "examples": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Sample values demonstrating typical content for this prop"
+        }
       },
-      "required": ["type", "default"],
+      "required": ["type"],
       "additionalProperties": false
     },
     "IconProp": {
@@ -154,9 +159,14 @@
       "properties": {
         "type": { "type": "string", "const": "string" },
         "default": { "type": "string" },
-        "nullable": { "type": "boolean" }
+        "nullable": { "type": "boolean" },
+        "examples": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Sample values demonstrating typical content for this prop"
+        }
       },
-      "required": ["type", "default"],
+      "required": ["type"],
       "additionalProperties": false
     },
     "EnumProp": {

--- a/tests/Props.test-d.ts
+++ b/tests/Props.test-d.ts
@@ -1,0 +1,58 @@
+/**
+ * Type-level tests for TextProp and IconProp examples field
+ * and optional default.
+ *
+ * These files are intentionally never executed — they are compiled with tsc
+ * to assert that the type shape is correct.
+ */
+import type { TextProp, IconProp, BooleanProp, EnumProp, SlotProp } from '../types/index.js';
+
+// ─── TextProp — examples field ──────────────────────────────────────────────
+
+// examples is optional and accepts string[]
+const textWithExamples: TextProp = { type: 'string', examples: ['Label', 'Title'] };
+const textNoExamples: TextProp = { type: 'string' };
+
+// default is now optional
+const textWithDefault: TextProp = { type: 'string', default: 'Label' };
+const textBoth: TextProp = { type: 'string', default: 'Label', examples: ['Label'] };
+
+// @ts-expect-error: examples must be string[], not number[]
+const _textBadExamples: TextProp = { type: 'string', examples: [42] };
+
+// @ts-expect-error: examples must be an array, not a string
+const _textBadExamplesStr: TextProp = { type: 'string', examples: 'Label' };
+
+// ─── IconProp — examples field ──────────────────────────────────────────────
+
+// examples is optional and accepts string[]
+const iconWithExamples: IconProp = { type: 'string', examples: ['Check', 'Close'] };
+const iconNoExamples: IconProp = { type: 'string' };
+
+// default is now optional
+const iconWithDefault: IconProp = { type: 'string', default: 'Check' };
+const iconBoth: IconProp = { type: 'string', default: 'Check', examples: ['Check'] };
+
+// @ts-expect-error: examples must be string[], not number[]
+const _iconBadExamples: IconProp = { type: 'string', examples: [42] };
+
+// ─── BooleanProp — default remains required, no examples ────────────────────
+
+const boolProp: BooleanProp = { type: 'boolean', default: true };
+
+// @ts-expect-error: default is required on BooleanProp
+const _boolNoDefault: BooleanProp = { type: 'boolean' };
+
+// ─── EnumProp — default remains required, no examples ───────────────────────
+
+const enumProp: EnumProp = { type: 'string', default: 'sm', enum: ['sm', 'md', 'lg'] };
+
+// @ts-expect-error: default is required on EnumProp
+const _enumNoDefault: EnumProp = { type: 'string', enum: ['sm', 'md'] };
+
+// ─── SlotProp — default remains required, no examples ───────────────────────
+
+const slotProp: SlotProp = { type: 'slot', default: 'Content' };
+
+// @ts-expect-error: default is required on SlotProp
+const _slotNoDefault: SlotProp = { type: 'slot' };

--- a/types/Props.ts
+++ b/types/Props.ts
@@ -21,8 +21,11 @@ export interface BooleanProp {
  */
 export interface TextProp {
   type: 'string';
-  default: string;
+  /** @deprecated Use `examples` for demo content */
+  default?: string;
   nullable?: boolean;
+  /** Sample values demonstrating typical content for this prop */
+  examples?: string[];
 }
 
 /**
@@ -30,8 +33,11 @@ export interface TextProp {
  */
 export interface IconProp {
   type: 'string';
-  default: string;
+  /** @deprecated Use `examples` for demo content */
+  default?: string;
   nullable?: boolean;
+  /** Sample values demonstrating typical content for this prop */
+  examples?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add optional `examples: string[]` field to `TextProp` and `IconProp` for sample/demo content
- Make `default` optional on both types (deprecated in favor of `examples`)
- Update `component.schema.json` with matching property additions and relaxed `required` arrays
- Add type-level tests in `tests/Props.test-d.ts`
- Update ADR create agent to sync release branch before numbering

## ADR

`adr/014-prop-examples.md` — Status: **ACCEPTED**

All validation gates passed:
- TypeScript compilation
- JSON Schema validation (4/4)
- Type tests compilation

## Test plan

- [x] `tsc -p tsconfig.build.json --noEmit` passes
- [x] `validate-schema.sh` passes (4/4 schemas)
- [x] `tsc --noEmit --strict tests/*.test-d.ts` passes
- [x] `BooleanProp`, `EnumProp`, `SlotProp` unaffected (default still required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)