### PR TITLE
ADR 016: Replace Element.text with Element.content

### DIFF
--- a/.github/agents/Anova.adr.create.agent.md
+++ b/.github/agents/Anova.adr.create.agent.md
@@ -32,7 +32,10 @@ You **MUST** consider the user input before proceeding (if not empty).
    - If the branch is `main` or doesn't match either pattern, fall back to reading `package.json` version and using the current minor version as `RELEASE_BRANCH`.
 
    **Step 1b — Sync release branch and determine next ADR number (silent, no user prompt)**
-   Run `git fetch origin $RELEASE_BRANCH` and fast-forward the local branch if behind (`git pull origin $RELEASE_BRANCH`). Then list `adr/` on the synced branch to find the highest existing ADR number and compute `NEXT_ADR_NUMBER` (zero-padded to 3 digits).
+   Run `git fetch origin $RELEASE_BRANCH` and fast-forward the local branch if behind (`git pull origin $RELEASE_BRANCH`). Then determine `NEXT_ADR_NUMBER` by finding the highest existing ADR number across **both** sources (zero-padded to 3 digits):
+   1. List `adr/` on the synced branch to find numbered ADR files (e.g., `014-prop-examples.md` → 14).
+   2. List remote branches matching the `###-*` pattern (`git branch -r --list 'origin/[0-9][0-9][0-9]-*'`) to find in-flight ADR branches that may not have merged files yet (e.g., `origin/015-some-feature` → 15).
+   Take the maximum number from both sources and add 1.
 
    **Step 1c — Ask the user** using VS Code's interactive question UI. Present ALL questions in a single prompt:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Styles.fillColor` — icon fill color for ICON element type
 - `TextProp.examples` — sample values demonstrating typical text content
 - `IconProp.examples` — sample values demonstrating typical icon content
+- `Element.content` — unified content for text strings and icon glyph names
 
 ### Changed
 
 - `TextProp.default` — now optional; use `examples` for demo content
 - `IconProp.default` — now optional; use `examples` for demo content
+- `BindingKey` — `'text'` replaced by `'content'`
 
 ### Removed
+
+- `Element.text` — use `Element.content` instead
+
+### Migration
+
+- `Element.text` → `Element.content`: read element content from `content` instead of `text`; applies to both text strings and icon glyph names
 
 ## [0.12.0] - 2026-03-05
 

--- a/adr/016-element-content.md
+++ b/adr/016-element-content.md
@@ -1,0 +1,186 @@
+# ADR: Element Content Identification
+
+**Branch**: `016-element-content`
+**Created**: 2026-03-10
+**Status**: ACCEPTED
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+The `Element` type currently includes a `text` property that captures the content of text-type anatomy elements:
+
+```yaml
+# types/Element.ts — current shape
+Element:
+  children?: Children
+  parent?: string | null
+  styles?: Styles
+  propConfigurations?: PropConfigurations
+  instanceOf?: string | PropBinding
+  text?: string | PropBinding          # text content only
+```
+
+This property serves text elements well — it captures literal string content or a prop binding reference for text that varies by variant. However, icon elements (element type `icon`) have an analogous concept: the **name** of the icon glyph being displayed (e.g., `caret-down`, `close`, `search`). Today there is no field on `Element` to capture this.
+
+ADR `011-icon-glyph-as-content` added `iconNamePattern` config so the transformer can detect icon component assets. ADR `013-icon-fillColor` added a dedicated `fillColor` style for icon coloring. But the element definition still lacks a way to record *which* icon glyph an element displays.
+
+The `text` property name is specific to one element type. Adding a parallel `iconName` (or similar) field creates a pattern where each content-bearing element type gets its own top-level field — an approach that does not scale and creates ambiguity about which field applies when.
+
+---
+
+## Decision Drivers
+
+- **Additive-only for MINOR**: Avoid breaking changes to preserve a MINOR bump; existing `text` usage must remain valid during any transition
+- **Type ↔ schema symmetry**: Every type change must have a corresponding schema change (Constitution I)
+- **No runtime logic**: Fields are pure data shapes only (Constitution II)
+- **Semantic clarity**: A field's name should describe its role without requiring knowledge of which element type it belongs to
+- **Scalability**: The solution should accommodate future content-bearing element types (e.g., media, embedded content) without proliferating top-level fields
+
+---
+
+## Options Considered
+
+### Option A: Add a `content` field and remove `text` *(Selected)*
+
+Add a new optional `content` field of type `string | PropBinding` that serves as the unified content identifier for any content-bearing element type. For `text` elements, `content` holds the text string or text prop binding. For `icon` elements, `content` holds the icon glyph name or an instance swap prop binding.
+
+Remove `text` immediately — no deprecation period. Pre-1.0 semver permits breaking changes in MINOR releases, and `0.13.0` already includes other breaking changes.
+
+```yaml
+# Element — new shape
+Element:
+  children?: Children
+  parent?: string | null
+  styles?: Styles
+  propConfigurations?: PropConfigurations
+  instanceOf?: string | PropBinding
+  content?: string | PropBinding       # replaces text
+```
+
+**Pros**:
+- Single field covers text content, icon glyph names, and future content types
+- Scales to new element types without new fields
+- Clean break — no dual-field ambiguity for consumers
+
+**Cons / Trade-offs**:
+- Breaking change for consumers currently reading `Element.text`
+
+---
+
+### Option B: Add a separate `name` field for icon elements
+
+Add an optional `name` field to `Element` specifically for icon glyph identification.
+
+```yaml
+Element:
+  name?: string | PropBinding          # icon glyph name
+  text?: string | PropBinding          # text content (unchanged)
+```
+
+**Rejected because**: Creates a pattern of per-type content fields on `Element`. Each new content-bearing element type would require yet another top-level field. The field name `name` is also ambiguous — it could be confused with the element's own name (its key in the `Elements` record). Violates the scalability driver.
+
+---
+
+### Option C: Keep `text` and overload it for icon content
+
+Reuse the existing `text` field for both text content and icon glyph names.
+
+```yaml
+# No schema change — text field used for both
+Element:
+  text?: string | PropBinding          # text content OR icon glyph name
+```
+
+**Rejected because**: The field name `text` strongly implies text-specific content. Overloading it for icon glyph names creates semantic confusion — consumers would need to cross-reference the anatomy element type to interpret the field correctly. The spec contract should be self-describing per the semantic clarity driver.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Element.ts` | Added optional field `content?: string \| PropBinding` | MINOR |
+| `Element.ts` | Removed field `text` | MAJOR |
+| `PropBinding.ts` | Changed `BindingKey` — `'text'` replaced by `'content'` | MAJOR |
+
+**Example — new shape** (`types/Element.ts`):
+```yaml
+# Before
+Element:
+  children?: Children
+  parent?: string | null
+  styles?: Styles
+  propConfigurations?: PropConfigurations
+  instanceOf?: string | PropBinding
+  text?: string | PropBinding
+
+# After
+Element:
+  children?: Children
+  parent?: string | null
+  styles?: Styles
+  propConfigurations?: PropConfigurations
+  instanceOf?: string | PropBinding
+  content?: string | PropBinding        # replaces text
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Added optional property `content` to `Element` definition | MINOR |
+| `component.schema.json` | Removed property `text` from `Element` definition | MAJOR |
+
+**Example — new shape** (`schema/component.schema.json`):
+```yaml
+# New property under #/definitions/Element/properties
+content:
+  oneOf:
+    - type: string
+    - $ref: "#/definitions/PropBinding"
+  description: "The content for content-bearing elements: text string for text elements, glyph name for icon elements, or a PropBinding reference"
+
+# text property removed entirely
+```
+
+### Notes
+
+- The `content` field is intentionally the same type as `text` (`string | PropBinding`) — it is a direct replacement, not a new shape.
+- `text` is removed immediately with no deprecation period. Pre-1.0 semver permits breaking changes in MINOR releases.
+
+---
+
+## Type <> Schema Impact
+
+- **Symmetric**: Yes — `content` is added to both `types/Element.ts` and `schema/component.schema.json#/definitions/Element/properties`
+- **Parity check**: `Element.content` (type) maps to `Element.properties.content` (schema); both accept `string | PropBinding`
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `anova-kit` | Recompile; update consumers to read `content` field | Adopt `content` for icon and text element output; continue supporting `text` until removal |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.13.0` (`MINOR`)
+
+**Justification**: `Element.text` is removed and replaced by `Element.content`; `BindingKey` changes from `'text'` to `'content'`. These are breaking changes, but pre-1.0 semver permits breaking changes in MINOR releases. The `0.13.0` release already includes other breaking changes.
+
+---
+
+## Consequences
+
+- Consumers can now access icon glyph names via `Element.content` in the spec output
+- Text element content moves from `Element.text` to `Element.content` — consumers must update reads
+- Future content-bearing element types can use the same `content` field without adding new top-level properties
+- `BindingKey` consumers must update `'text'` references to `'content'`

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -292,12 +292,12 @@
           ],
           "description": "The component or component set name that this instance element references, or a reference to an instance swap prop binding"
         },
-        "text": {
+        "content": {
           "oneOf": [
             { "type": "string" },
             { "$ref": "#/definitions/PropBinding" }
           ],
-          "description": "The text content for text elements, or a reference to a text prop binding"
+          "description": "The content for content-bearing elements: text string for text elements, glyph name for icon elements, or a PropBinding reference"
         },
         "styles": { "$ref": "#/definitions/Styles" },
         "propConfigurations": { "$ref": "#/definitions/PropConfigurations" }

--- a/tests/Element.test-d.ts
+++ b/tests/Element.test-d.ts
@@ -1,0 +1,25 @@
+/**
+ * Type-level tests for Element.content field.
+ *
+ * These files are intentionally never executed — they are compiled with tsc
+ * to assert that the type shape is correct.
+ */
+import type { Element, PropBinding } from '../types/index.js';
+
+// ─── Element.content accepts string | PropBinding ───────────────────────────
+
+const contentString: Element = { content: 'Submit' };
+const contentIcon: Element = { content: 'caret-down' };
+const contentBound: Element = { content: { $binding: '#/props/label' } };
+
+// content is optional — empty element is valid
+const emptyElement: Element = {};
+
+// Old { $ref } shape must NOT compile as Element.content
+// @ts-expect-error: { $ref } is not valid for content
+const _oldContent: Element = { content: { $ref: '#/props/label' } };
+
+// ─── Element.text has been removed ──────────────────────────────────────────
+
+// @ts-expect-error: text property no longer exists on Element
+const _removedText: Element = { text: 'Submit' };

--- a/tests/PropBinding.test-d.ts
+++ b/tests/PropBinding.test-d.ts
@@ -33,6 +33,9 @@ const _badBindingRef: PropBinding = { $binding: '#/props/x', $ref: '#/props/x' }
 const _bkChildren: BindingKey = 'children';
 const _bkInstanceOf: BindingKey = 'instanceOf';
 const _bkVisible: BindingKey = 'visible';
+const _bkContent: BindingKey = 'content';
+
+// @ts-expect-error: 'text' is no longer a BindingKey — replaced by 'content'
 const _bkText: BindingKey = 'text';
 
 // @ts-expect-error: 'styles' is not a BindingKey
@@ -47,14 +50,14 @@ const elemBound: Element = { instanceOf: { $binding: '#/props/swap' } };
 // @ts-expect-error: ReferenceValue ($ref) is no longer valid for instanceOf
 const _oldInstanceOf: Element = { instanceOf: { $ref: '#/props/swap' } };
 
-// ─── Element.text accepts string | PropBinding ──────────────────────────────
+// ─── Element.content accepts string | PropBinding ───────────────────────────
 
-const textUnbound: Element = { text: 'Submit' };
-const textBound: Element = { text: { $binding: '#/props/label' } };
+const contentUnbound: Element = { content: 'Submit' };
+const contentBound: Element = { content: { $binding: '#/props/label' } };
 
-// Old { $ref } shape must NOT compile as Element.text
-// @ts-expect-error: ReferenceValue ($ref) is no longer valid for text
-const _oldText: Element = { text: { $ref: '#/props/label' } };
+// Old { $ref } shape must NOT compile as Element.content
+// @ts-expect-error: ReferenceValue ($ref) is no longer valid for content
+const _oldContent: Element = { content: { $ref: '#/props/label' } };
 
 // ─── Style accepts PropBinding (for visible) ────────────────────────────────
 

--- a/types/Element.ts
+++ b/types/Element.ts
@@ -17,7 +17,8 @@ export type Element = {
   styles?: Styles;
   propConfigurations?: PropConfigurations;
   instanceOf?: string | PropBinding;
-  text?: string | PropBinding;
+  /** The content for content-bearing elements: text string for text elements, glyph name for icon elements, or a PropBinding reference. */
+  content?: string | PropBinding;
 };
 
 /**

--- a/types/PropBinding.ts
+++ b/types/PropBinding.ts
@@ -15,6 +15,6 @@ export interface PropBinding {
 
 /**
  * Keys for properties that can be bound to component props.
- * Maps to Element properties: `instanceOf`, `text`, `children`; and Style property: `visible`.
+ * Maps to Element properties: `instanceOf`, `content`, `children`; and Style property: `visible`.
  */
-export type BindingKey = 'children' | 'instanceOf' | 'visible' | 'text';
+export type BindingKey = 'children' | 'instanceOf' | 'visible' | 'content';


### PR DESCRIPTION
## Summary

- Add unified `Element.content` field (`string | PropBinding`) for text strings, icon glyph names, and future content-bearing element types
- Remove `Element.text` immediately (no deprecation period)
- Update `BindingKey`: `'text'` → `'content'`

## ADR

[016-element-content](adr/016-element-content.md) — **ACCEPTED**

## Test plan

- [x] TypeScript compilation passes (`tsc -p tsconfig.build.json --noEmit`)
- [x] JSON Schema validation passes (4/4 schemas)
- [x] Type-level tests compile (`tests/Element.test-d.ts`, `tests/PropBinding.test-d.ts`)
- [ ] Review diff for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)