### PR TITLE
feat(029): add NumberProp and Config.processing.inferNumberProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `NumberProp` — numeric property type for number-valued component props
+- `AnyProp` — `NumberProp` added as a fifth union member (`type: 'number'`)
+- `Config.processing.inferNumberProps` — opt-in flag to infer `NumberProp` from TEXT code-only props
+
 ### Changed
 
 ### Removed

--- a/adr/029-number-prop.md
+++ b/adr/029-number-prop.md
@@ -1,0 +1,233 @@
+# ADR: NumberProp — Numeric Property Type
+
+**Branch**: `029-number-prop`
+**Created**: 2026-03-17
+**Status**: ACCEPTED
+**Deciders**: (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+Figma has no native number type. Numeric values like `maxCharacterCount`, `minRows`, and `tabIndex` are stored as TEXT component properties with string content. The transformer currently emits these as `type: string` props (`StringProp`), which is technically faithful to Figma's representation but semantically wrong for consumers — these values are numbers and should be typed as such.
+
+**Precedent**: Boolean inference already exists. A VARIANT property with exactly the values `"true"` / `"false"` is emitted as `BooleanProp`. Number inference from TEXT props is the same pattern: deterministic when the inference guard is unambiguous, opt-in for the probabilistic case.
+
+**Current state of `AnyProp`**:
+```yaml
+# types/Props.ts — current union
+AnyProp: BooleanProp | StringProp | EnumProp | SlotProp
+```
+
+There is no `NumberProp` member in the union, no `type: 'number'` discriminant in the schema, and no `Config.processing` flag to control numeric inference.
+
+**Gap**: Consumers reading a component spec today cannot distinguish a numeric string like `"24"` (a `maxCharacterCount`) from a semantic string like `"Submit"` (a label). Both appear as `StringProp`. A `NumberProp` type makes the distinction explicit in the contract.
+
+---
+
+## Decision Drivers
+
+- **Type/schema parity (Principle I)**: `NumberProp` must be added to both `types/Props.ts` and `schema/component.schema.json` simultaneously. No drift.
+- **No logic in this package (Principle II)**: The inference algorithm (parsing, leading-zero guard) lives in `anova-transformer`. This ADR adds only the type and schema; it does not embed parsing logic.
+- **Minimal, stable, intentional API (Principle III)**: `NumberProp` represents a genuine shared concept — a numeric-valued component property — needed by all consumers. The `inferNumberProps` flag is a new optional field in `Config.processing`, which is additive.
+- **Target release `0.14.0` (in-flight MINOR)**: All changes land within the current `0.14.0` release cycle, which is already a MINOR bump from `0.13.x`. No additional version increment is required.
+- **Opt-in inference**: Numeric inference from TEXT props is probabilistic. An opt-in `Config.processing.inferNumberProps` flag ensures consumers that do not want inference are unaffected.
+
+---
+
+## Options Considered
+
+### Option A: Add `NumberProp` + `Config.processing.inferNumberProps` opt-in flag *(Selected)*
+
+Add a first-class `NumberProp` interface (`type: 'number'`, `default?: number`, `examples?: number[]`) to `types/Props.ts` and `AnyProp`. Add `inferNumberProps?: boolean` to `Config.processing`. Mirror both changes in `schema/component.schema.json`.
+
+**Inference guard — values that WILL be inferred as `NumberProp`** (all conditions must hold):
+- Source is a TEXT component property with `source.kind === 'codeOnlyProp'`
+- The `default` value and every entry in `examples` parse as a finite number via `Number()`
+- No value has a leading zero (rejects `"007"`, `"0800"`, `"01"`)
+- No value is the empty string
+
+**Values that will NOT be inferred** (remain `StringProp`):
+- `"0800"`, `"007"` — leading zero; likely an identifier or formatted code
+- `"1.0"`, `"2.0"` — trailing `.0`; likely a version string or display label
+- `""` — empty string; no numeric content
+- Any value where `Number(v)` returns `NaN` or `±Infinity`
+
+**Known false positives** (will be inferred, but may not be intended as numbers):
+- `"90210"` — passes all guard conditions (no leading zero, finite, non-empty); inferred as `NumberProp` even though it is a zip code. This is the canonical example of why the flag is opt-in: the guard is a heuristic and callers accept responsibility for false positives when enabling it.
+
+**Pros**:
+- Satisfies Principle I: symmetric type + schema addition.
+- Satisfies Principle II: no logic added to this package — the inference guard lives in `anova-transformer`.
+- Satisfies Principle III: `NumberProp` is a genuine shared concept; opt-in flag avoids forcing inference on consumers.
+- `default` and `examples` are optional — aligns with `StringProp` which also has optional `default`.
+
+**Cons / Trade-offs**:
+- Adds a new discriminant (`type: 'number'`) to `AnyProp`; downstream consumers doing exhaustive type checks must handle the new branch.
+- The leading-zero and trailing-`.0` guards are heuristics — edge cases exist, which is why the flag remains opt-in.
+
+---
+
+### Option B: Emit numeric values as `StringProp` with a semantic annotation *(Rejected)*
+
+Keep `StringProp` but add a `format: 'number'` or similar metadata field to signal that the string content is numeric.
+
+**Rejected because**: Creates implicit dual semantics on `StringProp` — consumers must inspect both `type` and `format` to determine the value's actual type. Violates the discriminated-union contract that the `type` field is the single source of truth. Also inconsistent with the `BooleanProp` precedent, which uses a distinct type discriminant.
+
+---
+
+### Option C: Always infer (no opt-in flag) *(Rejected)*
+
+Emit `NumberProp` whenever the inference guard passes, without a `Config.processing` flag.
+
+**Rejected because**: Numeric inference is probabilistic. `"0800"`, `"1.0"` (version string), and `"90210"` pass a naive `Number()` check but are not intended as numbers. An always-on inference would produce silent regressions for consumers with legitimate numeric-looking string props. Opt-in gives consumers explicit control.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Props.ts` | Add `NumberProp` interface | in-flight MINOR (`0.14.0`) |
+| `Props.ts` | Add `NumberProp` to `AnyProp` union | in-flight MINOR (`0.14.0`) |
+| `Config.ts` | Add `inferNumberProps?: boolean` to `Config.processing` | in-flight MINOR (`0.14.0`) |
+
+**Before → After: `AnyProp`** (`types/Props.ts`):
+```yaml
+# Before
+AnyProp: BooleanProp | StringProp | EnumProp | SlotProp
+
+# After
+AnyProp: BooleanProp | StringProp | EnumProp | SlotProp | NumberProp
+```
+
+**New type: `NumberProp`** (`types/Props.ts`):
+```yaml
+NumberProp:
+  type: 'number'          # discriminant
+  default?: number        # optional — omitted when no meaningful default exists
+  examples?: number[]     # sample numeric values for documentation
+```
+
+**Before → After: `Config.processing`** (`types/Config.ts`):
+```yaml
+# Before
+processing:
+  subcomponentNamePattern: string
+  glyphNamePattern?: string
+  variantDepth: 1 | 2 | 3 | 9999
+  details: 'FULL' | 'LAYERED'
+
+# After
+processing:
+  subcomponentNamePattern: string
+  glyphNamePattern?: string
+  variantDepth: 1 | 2 | 3 | 9999
+  details: 'FULL' | 'LAYERED'
+  inferNumberProps?: boolean     # opt-in: infer NumberProp from numeric TEXT code-only props
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Add `NumberProp` definition under `#/definitions` | in-flight MINOR (`0.14.0`) |
+| `component.schema.json` | Add `{ "$ref": "#/definitions/NumberProp" }` to `AnyProp.oneOf` | in-flight MINOR (`0.14.0`) |
+| `component.schema.json` | Add `inferNumberProps` optional boolean to `Config.processing.properties` | in-flight MINOR (`0.14.0`) |
+
+**New definition: `NumberProp`** (`schema/component.schema.json`):
+```yaml
+# Under #/definitions/NumberProp
+NumberProp:
+  type: object
+  properties:
+    type:
+      type: string
+      const: number
+    default:
+      type: number
+    examples:
+      type: array
+      items:
+        type: number
+      description: Sample numeric values demonstrating typical content for this prop
+  required:
+    - type
+  patternProperties:
+    "^\\$": {}
+  additionalProperties: false
+```
+
+**Updated `AnyProp.oneOf`** (`schema/component.schema.json`):
+```yaml
+# Before
+AnyProp:
+  oneOf:
+    - $ref: '#/definitions/BooleanProp'
+    - $ref: '#/definitions/StringProp'
+    - $ref: '#/definitions/EnumProp'
+    - $ref: '#/definitions/SlotProp'
+
+# After
+AnyProp:
+  oneOf:
+    - $ref: '#/definitions/BooleanProp'
+    - $ref: '#/definitions/StringProp'
+    - $ref: '#/definitions/EnumProp'
+    - $ref: '#/definitions/SlotProp'
+    - $ref: '#/definitions/NumberProp'
+```
+
+**Updated `Config.processing`** (`schema/component.schema.json`):
+```yaml
+# New property under #/definitions/Config/properties/processing/properties
+inferNumberProps:
+  type: boolean
+  description: "When true, TEXT code-only props whose default and all examples parse as valid numbers (no leading zeros) are emitted as NumberProp instead of StringProp"
+# NOT added to required[] — optional field
+```
+
+### Notes
+
+- `NumberProp.default` is optional (not in `required[]`) to mirror `StringProp`, which also has an optional `default`. Some numeric props may not have a meaningful default.
+- `NumberProp.examples` mirrors `StringProp.examples` — an array of sample values for documentation purposes.
+- `Config.processing.inferNumberProps` is optional and defaults to absent (falsy), preserving existing behavior for all current consumers.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**:
+  - `NumberProp` (interface in `types/Props.ts`) ↔ `#/definitions/NumberProp` (object definition in `schema/component.schema.json`)
+  - `AnyProp` union (`types/Props.ts`) ↔ `AnyProp.oneOf` array (`schema/component.schema.json`)
+  - `Config.processing.inferNumberProps` (`types/Config.ts`) ↔ `#/definitions/Config/properties/processing/properties/inferNumberProps` (`schema/component.schema.json`)
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `anova-kit` | New `NumberProp` member in `AnyProp` union; new optional `inferNumberProps` in `Config.processing` | Recompile; add exhaustive-switch handling for `type: 'number'` where `AnyProp` is branched on; optionally pass `inferNumberProps: true` in config to enable inference |
+
+---
+
+## Semver Decision
+
+**Version bump**: none — ships within `0.14.0` (in-flight MINOR)
+
+**Justification**: `0.14.0` is already a MINOR release cycle. All changes here are additive — a new optional type (`NumberProp`) in the `AnyProp` union and a new optional field (`inferNumberProps`) in `Config.processing`. No existing type, field, or schema property is removed or renamed. Per constitution Additional Constraints: "MINOR for additive types or new optional fields." No additional version increment is needed beyond the already-planned `0.14.0`.
+
+---
+
+## Consequences
+
+- Consumers can now represent numeric-valued component properties (`maxCharacterCount`, `minRows`, `tabIndex`, etc.) as `NumberProp` in the spec output, preserving semantic type information.
+- The `AnyProp` union gains a fifth discriminant (`type: 'number'`); any exhaustive type-switch over `AnyProp` must be updated to handle `NumberProp`.
+- `Config.processing.inferNumberProps` is opt-in and absent by default — existing consumers and specs are unaffected until they enable the flag.
+- The inference guard (TEXT source, code-only prop, all values parse as numbers without leading zeros) is enforced in `anova-transformer`, not in this package. This ADR records only the contract change.
+- Enum props with numeric values (e.g., `1 | 2 | 3 | 4`) are out of scope for this ADR. If Figma represents them as VARIANT properties, they continue to emit as `EnumProp` with string members. A separate ADR may address `NumberEnumProp` if that need arises.

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -11,32 +11,40 @@
       "description": "A component specification derived from Figma that defines structure, properties, variants, and styling rules.",
       "examples": [],
       "properties": {
-        "metadata": { "$ref": "#/definitions/Metadata" },
-        "title": { 
+        "metadata": {
+          "$ref": "#/definitions/Metadata"
+        },
+        "title": {
           "type": "string",
           "description": "The component asset name",
-          "examples": ["Button", "Card", "Text Input"]
+          "examples": [
+            "Button",
+            "Card",
+            "Text Input"
+          ]
         },
-        "anatomy": { 
+        "anatomy": {
           "$ref": "#/definitions/Anatomy",
           "description": "The elements that comprise the component, corresponding largely to Figma layers"
         },
-        "props": { 
+        "props": {
           "$ref": "#/definitions/Props",
           "description": "Configurable properties that control component behavior and appearance"
         },
-        "default": { 
+        "default": {
           "$ref": "#/definitions/Variant",
           "description": "The base variant configuration that's both the component default display as well as the foundation for all other variants"
         },
-        "variants": { 
+        "variants": {
           "$ref": "#/definitions/Variants",
           "description": "The styling, layout, and configuration of nested instances based on a cmoponent configuration"
         },
         "invalidVariantCombinations": {
           "type": "array",
           "description": "Non-default prop values that when used in combination result in an invalid component state, such as a component being set to disabled and hover simultaneously",
-          "items": { "$ref": "#/definitions/PropConfigurations" }
+          "items": {
+            "$ref": "#/definitions/PropConfigurations"
+          }
         },
         "subcomponents": {
           "type": "object",
@@ -46,19 +54,37 @@
           }
         }
       },
-      "required": ["title", "anatomy", "default"],
+      "required": [
+        "title",
+        "anatomy",
+        "default"
+      ],
       "additionalProperties": false
     },
     "Anatomy": {
       "type": "object",
       "description": "The structural elements that make up the component. Element names format depends on user settings.",
       "examples": [],
-      "additionalProperties": { "$ref": "#/definitions/AnatomyElement" }
+      "additionalProperties": {
+        "$ref": "#/definitions/AnatomyElement"
+      }
     },
     "ElementType": {
       "type": "string",
       "description": "Element types derived from Figma node analysis.",
-      "enum": ["text", "glyph", "vector", "container", "slot", "instance", "line", "ellipse", "rectangle", "polygon", "star"]
+      "enum": [
+        "text",
+        "glyph",
+        "vector",
+        "container",
+        "slot",
+        "instance",
+        "line",
+        "ellipse",
+        "rectangle",
+        "polygon",
+        "star"
+      ]
     },
     "ElementTypeRef": {
       "type": "object",
@@ -69,7 +95,9 @@
           "description": "URI reference to an external element type definition (e.g. 'foundations#/definitions/glyph')"
         }
       },
-      "required": ["$ref"],
+      "required": [
+        "$ref"
+      ],
       "additionalProperties": false
     },
     "AnatomyElement": {
@@ -79,31 +107,54 @@
       "properties": {
         "type": {
           "oneOf": [
-            { "$ref": "#/definitions/ElementType" },
-            { "$ref": "#/definitions/ElementTypeRef" }
+            {
+              "$ref": "#/definitions/ElementType"
+            },
+            {
+              "$ref": "#/definitions/ElementTypeRef"
+            }
           ],
           "description": "Element type as a plain string identifier or a reference to an external definition."
         },
-        "detectedIn": { "type": "string" },
-        "instanceOf": { "type": "string" }
+        "detectedIn": {
+          "type": "string"
+        },
+        "instanceOf": {
+          "type": "string"
+        }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     },
     "Props": {
       "type": "object",
       "description": "",
       "examples": [],
-      "additionalProperties": { "$ref": "#/definitions/AnyProp" }
+      "additionalProperties": {
+        "$ref": "#/definitions/AnyProp"
+      }
     },
     "AnyProp": {
       "description": "",
       "examples": [],
       "oneOf": [
-        { "$ref": "#/definitions/BooleanProp" },
-        { "$ref": "#/definitions/StringProp" },
-        { "$ref": "#/definitions/EnumProp" },
-        { "$ref": "#/definitions/SlotProp" }
+        {
+          "$ref": "#/definitions/BooleanProp"
+        },
+        {
+          "$ref": "#/definitions/StringProp"
+        },
+        {
+          "$ref": "#/definitions/EnumProp"
+        },
+        {
+          "$ref": "#/definitions/SlotProp"
+        },
+        {
+          "$ref": "#/definitions/NumberProp"
+        }
       ]
     },
     "BooleanProp": {
@@ -111,8 +162,13 @@
       "description": "",
       "examples": [],
       "properties": {
-        "type": { "type": "string", "const": "boolean" },
-        "default": { "type": "boolean" },
+        "type": {
+          "type": "string",
+          "const": "boolean"
+        },
+        "default": {
+          "type": "boolean"
+        },
         "x-platform": {
           "type": "object",
           "properties": {
@@ -121,18 +177,30 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["BOOLEAN", "TEXT", "INSTANCE_SWAP", "VARIANT"]
+                  "enum": [
+                    "BOOLEAN",
+                    "TEXT",
+                    "INSTANCE_SWAP",
+                    "VARIANT"
+                  ]
                 }
               },
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "additionalProperties": false
             }
           },
           "additionalProperties": false
         }
       },
-      "required": ["type", "default"],
-      "patternProperties": { "^\\$": {} },
+      "required": [
+        "type",
+        "default"
+      ],
+      "patternProperties": {
+        "^\\$": {}
+      },
       "additionalProperties": false
     },
     "StringProp": {
@@ -140,17 +208,33 @@
       "description": "String property definition for text content, glyph/instance swap, or other string-valued props.",
       "examples": [],
       "properties": {
-        "type": { "type": "string", "const": "string" },
-        "default": { "type": ["string", "null"] },
-        "nullable": { "type": "boolean" },
+        "type": {
+          "type": "string",
+          "const": "string"
+        },
+        "default": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "nullable": {
+          "type": "boolean"
+        },
         "examples": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Sample values demonstrating typical content for this prop"
         }
       },
-      "required": ["type"],
-      "patternProperties": { "^\\$": {} },
+      "required": [
+        "type"
+      ],
+      "patternProperties": {
+        "^\\$": {}
+      },
       "additionalProperties": false
     },
     "EnumProp": {
@@ -158,16 +242,31 @@
       "description": "",
       "examples": [],
       "properties": {
-        "type": { "type": "string", "const": "string" },
-        "default": { "type": "string" },
+        "type": {
+          "type": "string",
+          "const": "string"
+        },
+        "default": {
+          "type": "string"
+        },
         "enum": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
-        "nullable": { "type": "boolean" }
+        "nullable": {
+          "type": "boolean"
+        }
       },
-      "required": ["type", "default", "enum"],
-      "patternProperties": { "^\\$": {} },
+      "required": [
+        "type",
+        "default",
+        "enum"
+      ],
+      "patternProperties": {
+        "^\\$": {}
+      },
       "additionalProperties": false
     },
     "SlotProp": {
@@ -175,34 +274,62 @@
       "description": "",
       "examples": [],
       "properties": {
-        "type": { "type": "string", "const": "slot" },
-        "default": { "type": ["null", "string"] },
-        "nullable": { "type": "boolean" }
+        "type": {
+          "type": "string",
+          "const": "slot"
+        },
+        "default": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "nullable": {
+          "type": "boolean"
+        }
       },
-      "required": ["type"],
-      "patternProperties": { "^\\$": {} },
+      "required": [
+        "type"
+      ],
+      "patternProperties": {
+        "^\\$": {}
+      },
       "additionalProperties": false
     },
     "Variants": {
       "type": "array",
       "description": "Variants is an array of variant items, each corresponding to a specific set of non-default prop configurations taht represent a Figma variant. Evaluating a variant's style requires including layering the element styles, configurations and other properties from *every* variant that matches any of the combinations of non-defualt properties. This behavior is similar to the CSS cascade.",
       "examples": [],
-      "items": { "$ref": "#/definitions/Variant" }
+      "items": {
+        "$ref": "#/definitions/Variant"
+      }
     },
     "Variant": {
       "type": "object",
       "description": "",
       "examples": [],
       "properties": {
-        "name": { "type": "string" },
-        "baseline": { "type": "string" },
-        "configuration": { "$ref": "#/definitions/PropConfigurations" },
-        "invalid": { "type": "boolean" },
+        "name": {
+          "type": "string"
+        },
+        "baseline": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "#/definitions/PropConfigurations"
+        },
+        "invalid": {
+          "type": "boolean"
+        },
         "layout": {
           "type": "array",
-          "items": { "$ref": "#/definitions/LayoutNode" }
+          "items": {
+            "$ref": "#/definitions/LayoutNode"
+          }
         },
-        "elements": { "$ref": "#/definitions/Elements" }
+        "elements": {
+          "$ref": "#/definitions/Elements"
+        }
       },
       "additionalProperties": false
     },
@@ -222,12 +349,16 @@
         }
       ],
       "oneOf": [
-        { "type": "string" },
+        {
+          "type": "string"
+        },
         {
           "type": "object",
           "additionalProperties": {
             "type": "array",
-            "items": { "$ref": "#/definitions/LayoutNode" }
+            "items": {
+              "$ref": "#/definitions/LayoutNode"
+            }
           }
         }
       ]
@@ -238,9 +369,15 @@
       "examples": [],
       "additionalProperties": {
         "oneOf": [
-          { "type": "string" },
-          { "type": "number" },
-          { "type": "boolean" }
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          }
         ]
       }
     },
@@ -248,7 +385,9 @@
       "type": "object",
       "description": "",
       "examples": [],
-      "additionalProperties": { "$ref": "#/definitions/Element" }
+      "additionalProperties": {
+        "$ref": "#/definitions/Element"
+      }
     },
     "Element": {
       "type": "object",
@@ -259,34 +398,54 @@
           "oneOf": [
             {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             },
-            { "$ref": "#/definitions/PropBinding" }
+            {
+              "$ref": "#/definitions/PropBinding"
+            }
           ],
           "description": "Child element names, or a PropBinding when bound to a slot prop"
         },
         "parent": {
           "oneOf": [
-            { "type": "string" },
-            { "type": "null" }
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "instanceOf": {
           "oneOf": [
-            { "type": "string" },
-            { "$ref": "#/definitions/PropBinding" }
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/PropBinding"
+            }
           ],
           "description": "The component or component set name that this instance element references, or a reference to an instance swap prop binding"
         },
         "content": {
           "oneOf": [
-            { "type": "string" },
-            { "$ref": "#/definitions/PropBinding" }
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/PropBinding"
+            }
           ],
           "description": "The content for content-bearing elements: text string for text elements, glyph name for glyph elements, or a PropBinding reference"
         },
-        "styles": { "$ref": "#/definitions/Styles" },
-        "propConfigurations": { "$ref": "#/definitions/PropConfigurations" }
+        "styles": {
+          "$ref": "#/definitions/Styles"
+        },
+        "propConfigurations": {
+          "$ref": "#/definitions/PropConfigurations"
+        }
       },
       "additionalProperties": false
     },
@@ -299,7 +458,9 @@
           "description": "JSON Pointer to the bound prop within this spec's props block, e.g. '#/props/propName'"
         }
       },
-      "required": ["$binding"],
+      "required": [
+        "$binding"
+      ],
       "additionalProperties": false
     },
     "ConditionArgs": {
@@ -312,15 +473,25 @@
         },
         "compareTo": {
           "oneOf": [
-            { "type": "string" },
-            { "type": "number" },
-            { "type": "boolean" },
-            { "type": "null" }
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
           ],
           "description": "Comparison operand for binary operations (equals, notEquals). Omitted for unary operations."
         }
       },
-      "required": ["value"],
+      "required": [
+        "value"
+      ],
       "additionalProperties": false
     },
     "ConditionExpression": {
@@ -335,7 +506,10 @@
           "$ref": "#/definitions/ConditionArgs"
         }
       },
-      "required": ["operation", "args"],
+      "required": [
+        "operation",
+        "args"
+      ],
       "additionalProperties": false
     },
     "Conditional": {
@@ -351,27 +525,49 @@
             "then": {
               "description": "Value when condition is true",
               "oneOf": [
-                { "type": "string" },
-                { "type": "boolean" },
-                { "type": "number" },
-                { "type": "null" }
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "else": {
               "description": "Value when condition is false",
               "oneOf": [
-                { "type": "string" },
-                { "type": "boolean" },
-                { "type": "number" },
-                { "type": "null" }
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
               ]
             }
           },
-          "required": ["condition", "then", "else"],
+          "required": [
+            "condition",
+            "then",
+            "else"
+          ],
           "additionalProperties": false
         }
       },
-      "required": ["if"],
+      "required": [
+        "if"
+      ],
       "additionalProperties": false
     },
     "Styles": {
@@ -381,14 +577,24 @@
       "type": "object",
       "description": "Metadata about the component, its author, generator, schema, and Figma source.",
       "properties": {
-        "author": { "type": "string" },
-        "lastUpdated": { "type": "string" },
+        "author": {
+          "type": "string"
+        },
+        "lastUpdated": {
+          "type": "string"
+        },
         "generator": {
           "type": "object",
           "properties": {
-            "url": { "type": "string" },
-            "version": { "type": "number" },
-            "name": { "type": "string" },
+            "url": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            },
             "license": {
               "type": "object",
               "description": "Resolved license state at the time this component spec was generated. Absent when no license was supplied.",
@@ -402,11 +608,18 @@
                   "description": "Output entitlement level (e.g. FREE, PRO, EXTENDED). Plain string for extensibility."
                 }
               },
-              "required": ["status", "level"],
+              "required": [
+                "status",
+                "level"
+              ],
               "additionalProperties": false
             }
           },
-          "required": ["url", "version", "name"],
+          "required": [
+            "url",
+            "version",
+            "name"
+          ],
           "additionalProperties": false
         },
         "schema": {
@@ -416,28 +629,57 @@
               "type": "string",
               "description": "Versioned schema URL pinned to a git tag (e.g. https://raw.githubusercontent.com/.../v0.13.0/schema/component.schema.json)"
             },
-            "version": { "type": "string" },
+            "version": {
+              "type": "string"
+            },
             "latest": {
               "type": "string",
               "description": "Stable URL pointing to the latest schema on the main branch for discovery"
             }
           },
-          "required": ["url", "version"],
+          "required": [
+            "url",
+            "version"
+          ],
           "additionalProperties": false
         },
         "source": {
           "type": "object",
           "properties": {
-            "pageId": { "type": "string" },
-            "nodeId": { "type": "string" },
-            "nodeType": { "type": "string", "enum": ["COMPONENT", "COMPONENT_SET", "FRAME"] }
+            "pageId": {
+              "type": "string"
+            },
+            "nodeId": {
+              "type": "string"
+            },
+            "nodeType": {
+              "type": "string",
+              "enum": [
+                "COMPONENT",
+                "COMPONENT_SET",
+                "FRAME"
+              ]
+            }
           },
-          "required": ["pageId", "nodeId", "nodeType"],
+          "required": [
+            "pageId",
+            "nodeId",
+            "nodeType"
+          ],
           "additionalProperties": false
         },
-        "config": { "$ref": "#/definitions/Config" }
+        "config": {
+          "$ref": "#/definitions/Config"
+        }
       },
-      "required": ["author", "lastUpdated", "generator", "schema", "source", "config"],
+      "required": [
+        "author",
+        "lastUpdated",
+        "generator",
+        "schema",
+        "source",
+        "config"
+      ],
       "additionalProperties": false
     },
     "Config": {
@@ -447,43 +689,120 @@
         "processing": {
           "type": "object",
           "properties": {
-            "subcomponentNamePattern": { "type": "string" },
-            "glyphNamePattern": { "type": "string", "description": "Naming pattern used to detect glyph content assets (e.g. 'DS Icon Glyph /')" },
-            "variantDepth": { "type": "number", "enum": [1, 2, 3, 9999] },
-            "details": { "type": "string", "enum": ["FULL", "LAYERED"] }
+            "subcomponentNamePattern": {
+              "type": "string"
+            },
+            "glyphNamePattern": {
+              "type": "string",
+              "description": "Naming pattern used to detect glyph content assets (e.g. 'DS Icon Glyph /')"
+            },
+            "variantDepth": {
+              "type": "number",
+              "enum": [
+                1,
+                2,
+                3,
+                9999
+              ]
+            },
+            "details": {
+              "type": "string",
+              "enum": [
+                "FULL",
+                "LAYERED"
+              ]
+            },
+            "inferNumberProps": {
+              "type": "boolean",
+              "description": "When true, TEXT code-only props whose default and all examples parse as valid numbers (no leading zeros) are emitted as NumberProp instead of StringProp"
+            }
           },
-          "required": ["subcomponentNamePattern", "variantDepth", "details"],
+          "required": [
+            "subcomponentNamePattern",
+            "variantDepth",
+            "details"
+          ],
           "additionalProperties": false
         },
         "format": {
           "type": "object",
           "properties": {
-            "output": { "type": "string", "enum": ["JSON", "YAML"] },
-            "keys": { "type": "string", "enum": ["SAFE", "CAMEL", "SNAKE", "KEBAB", "PASCAL", "TRAIN"] },
-            "layout": { "type": "string", "enum": ["LAYOUT", "PARENT_CHILDREN", "BOTH"] },
+            "output": {
+              "type": "string",
+              "enum": [
+                "JSON",
+                "YAML"
+              ]
+            },
+            "keys": {
+              "type": "string",
+              "enum": [
+                "SAFE",
+                "CAMEL",
+                "SNAKE",
+                "KEBAB",
+                "PASCAL",
+                "TRAIN"
+              ]
+            },
+            "layout": {
+              "type": "string",
+              "enum": [
+                "LAYOUT",
+                "PARENT_CHILDREN",
+                "BOTH"
+              ]
+            },
             "tokens": {
               "type": "string",
-              "enum": ["TOKEN", "TOKEN_NAME", "TOKEN_FIGMA_EXTENSIONS", "FIGMA_NAME", "CUSTOM"],
+              "enum": [
+                "TOKEN",
+                "TOKEN_NAME",
+                "TOKEN_FIGMA_EXTENSIONS",
+                "FIGMA_NAME",
+                "CUSTOM"
+              ],
               "default": "TOKEN",
               "description": "Token reference serialization profile. Optional; defaults to TOKEN. CUSTOM delegates projection entirely to the transformer."
             }
           },
-          "required": ["output", "keys", "layout"],
+          "required": [
+            "output",
+            "keys",
+            "layout"
+          ],
           "additionalProperties": false
         },
         "include": {
           "type": "object",
           "properties": {
-            "subcomponents": { "type": "boolean" },
-            "variantNames": { "type": "boolean" },
-            "invalidVariants": { "type": "boolean" },
-            "invalidCombinations": { "type": "boolean" }
+            "subcomponents": {
+              "type": "boolean"
+            },
+            "variantNames": {
+              "type": "boolean"
+            },
+            "invalidVariants": {
+              "type": "boolean"
+            },
+            "invalidCombinations": {
+              "type": "boolean"
+            }
           },
-          "required": ["subcomponents", "variantNames", "invalidVariants", "invalidCombinations"],
+          "required": [
+            "subcomponents",
+            "variantNames",
+            "invalidVariants",
+            "invalidCombinations"
+          ],
           "additionalProperties": false
         }
       },
-      "required": ["processing", "format", "include"],
+      "required": [
+        "processing",
+        "format",
+        "include"
+      ],
       "additionalProperties": false
     },
     "Subcomponent": {
@@ -499,10 +818,41 @@
               "metadata": {},
               "subcomponents": {}
             },
-            "required": ["metadata", "subcomponents"]
+            "required": [
+              "metadata",
+              "subcomponents"
+            ]
           }
         }
       ]
+    },
+    "NumberProp": {
+      "type": "object",
+      "description": "Number property definition for numeric-valued props inferred from TEXT code-only props.",
+      "examples": [],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "number"
+        },
+        "default": {
+          "type": "number"
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Sample numeric values demonstrating typical content for this prop"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "patternProperties": {
+        "^\\$": {}
+      },
+      "additionalProperties": false
     }
   },
   "$ref": "#/definitions/Component"

--- a/tests/Config.test-d.ts
+++ b/tests/Config.test-d.ts
@@ -107,3 +107,29 @@ const configWithGlyph: Config = {
 
 // glyphNamePattern can be undefined
 const _glyphUndefined: Config['processing']['glyphNamePattern'] = undefined;
+
+// inferNumberProps is optional — Config compiles without it (ADR 029)
+const configWithoutInferNumber: Config = {
+  processing: {
+    subcomponentNamePattern: '{C} / _ / {S}',
+    variantDepth: 9999,
+    details: 'LAYERED',
+  },
+  format: { output: 'JSON', keys: 'SAFE', layout: 'LAYOUT' },
+  include: { subcomponents: false, variantNames: false, invalidVariants: false, invalidCombinations: true },
+};
+
+// inferNumberProps accepts true
+const configWithInferNumber: Config = {
+  processing: {
+    subcomponentNamePattern: '{C} / _ / {S}',
+    variantDepth: 9999,
+    details: 'LAYERED',
+    inferNumberProps: true,
+  },
+  format: { output: 'JSON', keys: 'SAFE', layout: 'LAYOUT' },
+  include: { subcomponents: false, variantNames: false, invalidVariants: false, invalidCombinations: true },
+};
+
+// inferNumberProps can be undefined
+const _inferUndefined: Config['processing']['inferNumberProps'] = undefined;

--- a/tests/Props.test-d.ts
+++ b/tests/Props.test-d.ts
@@ -5,7 +5,7 @@
  * These files are intentionally never executed — they are compiled with tsc
  * to assert that the type shape is correct.
  */
-import type { StringProp, BooleanProp, EnumProp, SlotProp, AnyProp } from '../types/index.js';
+import type { StringProp, BooleanProp, EnumProp, SlotProp, NumberProp, AnyProp } from '../types/index.js';
 
 // ─── StringProp — examples field ──────────────────────────────────────────────
 
@@ -75,3 +75,27 @@ const slotNoDefault: SlotProp = { type: 'slot' };
 
 // @ts-expect-error: default must be string | null, not number
 const _slotBadDefault: SlotProp = { type: 'slot', default: 42 };
+
+// ─── NumberProp (ADR 029) ─────────────────────────────────────────────────────
+
+// minimal valid NumberProp
+const numberMinimal: NumberProp = { type: 'number' };
+
+// with optional default
+const numberWithDefault: NumberProp = { type: 'number', default: 24 };
+
+// with optional examples
+const numberWithExamples: NumberProp = { type: 'number', examples: [1, 2, 3] };
+
+// with both
+const numberFull: NumberProp = { type: 'number', default: 1, examples: [1, 2, 4] };
+
+// @ts-expect-error: default must be number, not string
+const _numberStringDefault: NumberProp = { type: 'number', default: '24' };
+
+// @ts-expect-error: examples must be number[], not string[]
+const _numberStringExamples: NumberProp = { type: 'number', examples: ['1', '2'] };
+
+// NumberProp is assignable to AnyProp
+const anyFromNumber: AnyProp = { type: 'number' } satisfies NumberProp;
+const anyFromNumberFull: AnyProp = { type: 'number', default: 10, examples: [10, 20] } satisfies NumberProp;

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -16,6 +16,8 @@ export interface Config {
     variantDepth: 1 | 2 | 3 | 9999;
     /** Level of detail in output */
     details: 'FULL' | 'LAYERED';
+    /** When true, TEXT code-only props whose default and all examples parse as valid numbers (no leading zeros) are emitted as NumberProp instead of StringProp */
+    inferNumberProps?: boolean;
   };
   format: {
     /** Output format */

--- a/types/Props.ts
+++ b/types/Props.ts
@@ -6,7 +6,7 @@ export type Props = Record<string, AnyProp>;
 /**
  * Union of all supported property types
  */
-export type AnyProp = BooleanProp | StringProp | EnumProp | SlotProp;
+export type AnyProp = BooleanProp | StringProp | EnumProp | SlotProp | NumberProp;
 
 /**
  * Boolean property definition
@@ -36,6 +36,17 @@ export interface EnumProp {
   default: string;
   enum: string[];
   nullable?: boolean;
+}
+
+/**
+ * Number property definition (numeric-valued props inferred from TEXT code-only props)
+ */
+export interface NumberProp {
+  type: 'number';
+  /** Default numeric value. Optional — omitted when no meaningful default exists. */
+  default?: number;
+  /** Sample numeric values demonstrating typical content for this prop */
+  examples?: number[];
 }
 
 /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,7 +9,7 @@
 // Core component types
 export type { Component } from './Component.js';
 export type { Anatomy, AnatomyElement, ElementTypeRef } from './Anatomy.js';
-export type { Props, AnyProp, BooleanProp, StringProp, EnumProp, SlotProp } from './Props.js';
+export type { Props, AnyProp, BooleanProp, StringProp, EnumProp, SlotProp, NumberProp } from './Props.js';
 export type { Variant, Variants } from './Variant.js';
 export type { Metadata } from './Metadata.js';
 export type { Subcomponent, Subcomponents } from './Subcomponent.js';


### PR DESCRIPTION
## Summary

- Adds `NumberProp` interface (`type: 'number'`, `default?: number`, `examples?: number[]`) as a fifth member of the `AnyProp` union
- Adds `Config.processing.inferNumberProps?: boolean` opt-in flag for numeric inference from TEXT code-only props
- Mirrors both changes in `schema/component.schema.json`

## ADR

`adr/029-number-prop.md` — Status: ACCEPTED

## Gates passed

- `tsc -p tsconfig.build.json --noEmit` ✓
- `validate-schema.sh` (4/4) ✓
- `tsc --noEmit --strict tests/*.test-d.ts` ✓

## Closes

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)