### PR TITLE
ADR 030: SubcomponentRef for instanceOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `SubcomponentRef` — reference to a subcomponent definition via `{ $ref: "#/subcomponents/{key}" }`
+- `AnatomyElement.instanceOf` — widened to accept `string | SubcomponentRef`
+- `Element.instanceOf` — widened to accept `string | PropBinding | SubcomponentRef`
+
 ### Changed
 
 ### Removed

--- a/adr/030-subcomponent-refs.md
+++ b/adr/030-subcomponent-refs.md
@@ -1,0 +1,181 @@
+# ADR: Subcomponent `$ref` for `instanceOf`
+
+**Branch**: `030-subcomponent-refs`
+**Created**: 2026-03-23
+**Status**: ACCEPTED
+**Deciders**: Nathan Curtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+When a component contains subcomponents, anatomy items and elements that are instances of those subcomponents currently record `instanceOf` as a plain formatted string (e.g., `"egdsRadioButtonFormLabel"`). This is opaque — a consumer cannot distinguish a subcomponent reference from an arbitrary component name, nor can tooling follow the relationship programmatically.
+
+The `$ref` pattern already exists in this package: `ElementTypeRef` uses `{ $ref: string }` on `AnatomyElement.type` to express a machine-followable pointer to an external definition. The same pattern should apply to `instanceOf` when the target is a sibling subcomponent within the same spec.
+
+The transformer spec `016-subcomponent-references` defines the downstream behavior: when `instanceOf` matches a detected subcomponent, the serialized output should emit `{ $ref: "#/subcomponents/{key}" }` instead of a plain string. This ADR records the types/schema change required to support that output.
+
+---
+
+## Decision Drivers
+
+- **Additive-only change**: Widening a union type preserves backward compatibility and avoids a MAJOR bump. Existing plain-string `instanceOf` values remain valid.
+- **Type ↔ schema symmetry**: Both the TypeScript type and the JSON schema must reflect the new shape simultaneously (Constitution §I).
+- **No runtime logic**: This package defines types and schema only. The `$ref` resolution logic belongs in downstream packages (Constitution §II).
+- **Reuse existing patterns**: `ElementTypeRef` already establishes the `{ $ref: string }` object shape. A new `SubcomponentRef` type should follow the same structure for consistency.
+- **Schema-level validation for internal pointers**: Unlike `ElementTypeRef` (which targets arbitrary external URIs), `SubcomponentRef` always points within the same document at `#/subcomponents/{key}`. The schema should enforce this with a `pattern` constraint so malformed references are caught at validation time.
+- **PropBinding priority**: On `Element.instanceOf`, `PropBinding` (instance-swap binding) already occupies one union branch. The new `$ref` shape is a third branch — the three are mutually exclusive at runtime.
+
+---
+
+## Options Considered
+
+### Option A: Reuse `ElementTypeRef` for subcomponent references *(Rejected)*
+
+Use the existing `ElementTypeRef` type directly on `instanceOf`.
+
+**Rejected because**: `ElementTypeRef` is documented as referencing *element type definitions* (e.g., `foundations#/definitions/glyph`). Subcomponent references point to `#/subcomponents/{key}` — a different concept. Overloading the type conflates two distinct reference targets and makes schema documentation misleading.
+
+---
+
+### Option B: New `SubcomponentRef` type with `{ $ref: string }` *(Selected)*
+
+Introduce a dedicated `SubcomponentRef` type structurally identical to `ElementTypeRef` but semantically scoped to subcomponent pointers. Widen `instanceOf` on both `AnatomyElement` and `Element` to accept it.
+
+**Pros**:
+- Clear semantic distinction between element-type references and subcomponent references
+- Follows the established `{ $ref: string }` pattern — no new structural concepts
+- Additive union widening — fully backward-compatible
+
+**Cons / Trade-offs**:
+- Two structurally identical `{ $ref: string }` types exist. This is intentional: they represent different reference targets and may diverge in the future (e.g., `SubcomponentRef` could gain a `version` field).
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Anatomy.ts` | Add `SubcomponentRef` type; widen `AnatomyElement.instanceOf` to `string \| SubcomponentRef` | MINOR |
+| `Element.ts` | Widen `Element.instanceOf` to `string \| PropBinding \| SubcomponentRef` | MINOR |
+| `index.ts` | Export `SubcomponentRef` | MINOR |
+
+**New type** (`types/Anatomy.ts`):
+```yaml
+# New type
+SubcomponentRef:
+  $ref: string   # e.g., "#/subcomponents/formLabel"
+```
+
+**Before / after** — `AnatomyElement.instanceOf`:
+```yaml
+# Before
+instanceOf?: string
+
+# After
+instanceOf?: string | SubcomponentRef
+```
+
+**Before / after** — `Element.instanceOf`:
+```yaml
+# Before
+instanceOf?: string | PropBinding
+
+# After
+instanceOf?: string | PropBinding | SubcomponentRef
+```
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Add `SubcomponentRef` definition; widen `AnatomyElement.instanceOf` and `Element.instanceOf` to `oneOf` including the new definition | MINOR |
+
+**New definition** (`schema/component.schema.json`):
+```yaml
+# #/definitions/SubcomponentRef
+SubcomponentRef:
+  type: object
+  description: "Reference to a subcomponent definition within the same spec."
+  properties:
+    $ref:
+      type: string
+      pattern: "^#/subcomponents/.+"
+      description: "JSON Pointer to a subcomponent (e.g. '#/subcomponents/formLabel')"
+  required: [$ref]
+  additionalProperties: false
+```
+
+> **Why `pattern` here but not on `ElementTypeRef`?** `ElementTypeRef` targets arbitrary external URIs (e.g., `foundations#/definitions/glyph`) where constraining the format would be overly restrictive. `SubcomponentRef` is internal-only — it always points to `#/subcomponents/{key}` within the same document, so the target space is small, well-defined, and appropriate for schema-level enforcement.
+
+**Before / after** — `AnatomyElement.instanceOf`:
+```yaml
+# Before
+instanceOf:
+  type: string
+
+# After
+instanceOf:
+  oneOf:
+    - type: string
+    - $ref: "#/definitions/SubcomponentRef"
+```
+
+**Before / after** — `Element.instanceOf`:
+```yaml
+# Before
+instanceOf:
+  oneOf:
+    - type: string
+    - $ref: "#/definitions/PropBinding"
+
+# After
+instanceOf:
+  oneOf:
+    - type: string
+    - $ref: "#/definitions/PropBinding"
+    - $ref: "#/definitions/SubcomponentRef"
+```
+
+### Notes
+
+- `SubcomponentRef` is placed in `Anatomy.ts` alongside `ElementTypeRef` since both are reference-object types used within anatomy/element contexts.
+- The `FigmaCodeOnlySource.instanceOf` field (`Props.ts` line 24) is **not** widened — it records a raw component name for enum derivation, not a followable pointer. No change needed.
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**:
+  - `SubcomponentRef` type → `#/definitions/SubcomponentRef` schema definition
+  - `AnatomyElement.instanceOf` union widened in both type and schema
+  - `Element.instanceOf` union widened in both type and schema
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `anova-kit` | Recompile — `instanceOf` values may now be `{ $ref }` objects instead of strings | Update any code that reads `instanceOf` to handle the `SubcomponentRef` shape |
+
+---
+
+## Semver Decision
+
+**Version bump**: `0.15.0` → `0.15.0` (no version change — this is a MINOR-compatible addition within the current release cycle)
+
+**Justification**: All changes are additive: a new optional type (`SubcomponentRef`), a new schema definition, and union widening on existing optional fields. No existing valid values are invalidated. MINOR per Constitution §III and Versioning policy.
+
+---
+
+## Consequences
+
+- Consumers can programmatically distinguish subcomponent references from plain component names via the `{ $ref }` object shape
+- The `$ref` pattern is now used for two distinct reference types: element types (`ElementTypeRef`) and subcomponents (`SubcomponentRef`), establishing `{ $ref }` as the standard reference mechanism in the spec
+- Downstream packages (`anova-transformer`, `anova-kit`) that read `instanceOf` must handle the new union branch — but since the field is optional and additive, existing code continues to compile
+- Schema validators will accept both `"someString"` and `{ "$ref": "#/subcomponents/key" }` for `instanceOf` fields

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -100,6 +100,21 @@
       ],
       "additionalProperties": false
     },
+    "SubcomponentRef": {
+      "type": "object",
+      "description": "Reference to a subcomponent definition within the same spec.",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "pattern": "^#/subcomponents/.+",
+          "description": "JSON Pointer to a subcomponent (e.g. '#/subcomponents/formLabel')"
+        }
+      },
+      "required": [
+        "$ref"
+      ],
+      "additionalProperties": false
+    },
     "AnatomyElement": {
       "type": "object",
       "description": "An element within the anatomy of a component.",
@@ -120,7 +135,15 @@
           "type": "string"
         },
         "instanceOf": {
-          "type": "string"
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/SubcomponentRef"
+            }
+          ],
+          "description": "The component or component set name that this instance element references, or a subcomponent reference"
         }
       },
       "required": [
@@ -461,9 +484,12 @@
             },
             {
               "$ref": "#/definitions/PropBinding"
+            },
+            {
+              "$ref": "#/definitions/SubcomponentRef"
             }
           ],
-          "description": "The component or component set name that this instance element references, or a reference to an instance swap prop binding"
+          "description": "The component or component set name that this instance element references, a prop binding for instance swaps, or a subcomponent reference"
         },
         "content": {
           "oneOf": [

--- a/tests/Anatomy.test-d.ts
+++ b/tests/Anatomy.test-d.ts
@@ -3,7 +3,7 @@
  * These files are intentionally never executed — they are compiled with tsc
  * to assert that the type shape is correct.
  */
-import type { Anatomy, AnatomyElement, ElementTypeRef } from '../types/index.js';
+import type { Anatomy, AnatomyElement, ElementTypeRef, SubcomponentRef } from '../types/index.js';
 
 // AnatomyElement.type accepts ElementType values
 const textElement: AnatomyElement = { type: 'text' };
@@ -57,6 +57,29 @@ const anatomy: Anatomy = {
   root: { type: 'container' },
   label: { type: 'text' },
   icon: { type: { $ref: 'foundations#/definitions/glyph' } },
+};
+
+// ─── SubcomponentRef ────────────────────────────────────────────────────────
+
+// SubcomponentRef shape
+const subRef: SubcomponentRef = { $ref: '#/subcomponents/formLabel' };
+
+// @ts-expect-error — SubcomponentRef requires $ref field
+const invalidSubRef: SubcomponentRef = {};
+
+// @ts-expect-error — SubcomponentRef.$ref must be a string
+const invalidSubRefType: SubcomponentRef = { $ref: 42 };
+
+// AnatomyElement.instanceOf accepts SubcomponentRef
+const subRefElement: AnatomyElement = {
+  type: 'instance',
+  instanceOf: { $ref: '#/subcomponents/formLabel' },
+};
+
+// AnatomyElement.instanceOf still accepts plain string
+const stringInstanceOf: AnatomyElement = {
+  type: 'instance',
+  instanceOf: 'SomeComponent',
 };
 
 // Type guard discrimination works

--- a/tests/Element.test-d.ts
+++ b/tests/Element.test-d.ts
@@ -4,13 +4,19 @@
  * These files are intentionally never executed — they are compiled with tsc
  * to assert that the type shape is correct.
  */
-import type { Element, PropBinding } from '../types/index.js';
+import type { Element, PropBinding, SubcomponentRef } from '../types/index.js';
 
 // ─── Element.content accepts string | PropBinding ───────────────────────────
 
 const contentString: Element = { content: 'Submit' };
 const contentGlyph: Element = { content: 'caret-down' };
 const contentBound: Element = { content: { $binding: '#/props/label' } };
+
+// ─── Element.instanceOf accepts string | PropBinding | SubcomponentRef ──────
+
+const instanceString: Element = { instanceOf: 'Button' };
+const instanceBound: Element = { instanceOf: { $binding: '#/props/icon' } };
+const instanceSubRef: Element = { instanceOf: { $ref: '#/subcomponents/formLabel' } };
 
 // content is optional — empty element is valid
 const emptyElement: Element = {};

--- a/tests/PropBinding.test-d.ts
+++ b/tests/PropBinding.test-d.ts
@@ -46,9 +46,8 @@ const _badKey: BindingKey = 'styles';
 const elemUnbound: Element = { instanceOf: 'Button' };
 const elemBound: Element = { instanceOf: { $binding: '#/props/swap' } };
 
-// Old { $ref } shape must NOT compile as Element.instanceOf
-// @ts-expect-error: ReferenceValue ($ref) is no longer valid for instanceOf
-const _oldInstanceOf: Element = { instanceOf: { $ref: '#/props/swap' } };
+// { $ref } is now valid for instanceOf — it matches SubcomponentRef
+const _subcomponentRef: Element = { instanceOf: { $ref: '#/subcomponents/formLabel' } };
 
 // ─── Element.content accepts string | PropBinding ───────────────────────────
 

--- a/types/Anatomy.ts
+++ b/types/Anatomy.ts
@@ -16,6 +16,16 @@ export type ElementTypeRef = {
 };
 
 /**
+ * Reference to a subcomponent definition within the same spec.
+ * Used when an anatomy item or element is an instance of a sibling subcomponent.
+ * @since 0.15.0
+ */
+export type SubcomponentRef = {
+  /** JSON Pointer to a subcomponent (e.g. "#/subcomponents/formLabel"). */
+  $ref: string;
+};
+
+/**
  * Represents an element within the anatomy of a component.
  */
 export type AnatomyElement = {
@@ -25,6 +35,6 @@ export type AnatomyElement = {
    */
   type: ElementType | ElementTypeRef;
   detectedIn?: string;
-  /** The component or component set name that this instance element references. */
-  instanceOf?: string;
+  /** The component or component set name that this instance element references, or a subcomponent reference. */
+  instanceOf?: string | SubcomponentRef;
 };

--- a/types/Element.ts
+++ b/types/Element.ts
@@ -2,6 +2,7 @@ import { Children } from "./Children.js";
 import { Styles } from "./Styles.js";
 import { PropConfigurations } from "./PropConfigurations.js";
 import { PropBinding } from "./PropBinding.js";
+import { SubcomponentRef } from "./Anatomy.js";
 
 /**
  * Represents elements within a component.
@@ -16,7 +17,8 @@ export type Element = {
   parent?: string | null;
   styles?: Styles;
   propConfigurations?: PropConfigurations;
-  instanceOf?: string | PropBinding;
+  /** The component or component set name, a prop binding for instance swaps, or a subcomponent reference. */
+  instanceOf?: string | PropBinding | SubcomponentRef;
   /** The content for content-bearing elements: text string for text elements, glyph name for glyph elements, or a PropBinding reference. */
   content?: string | PropBinding;
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,7 +8,7 @@
 
 // Core component types
 export type { Component } from './Component.js';
-export type { Anatomy, AnatomyElement, ElementTypeRef } from './Anatomy.js';
+export type { Anatomy, AnatomyElement, ElementTypeRef, SubcomponentRef } from './Anatomy.js';
 export type { Props, AnyProp, BooleanProp, StringProp, EnumProp, SlotProp, NumberProp, FigmaCodeOnlySource, FigmaPropExtension, PropExtensions } from './Props.js';
 export type { Variant, Variants } from './Variant.js';
 export type { Metadata } from './Metadata.js';


### PR DESCRIPTION
## Summary

- Adds `SubcomponentRef` type (`{ $ref: string }`) with schema `pattern: "^#/subcomponents/.+"` constraint
- Widens `AnatomyElement.instanceOf` to `string | SubcomponentRef`
- Widens `Element.instanceOf` to `string | PropBinding | SubcomponentRef`
- Additive (MINOR) — no breaking changes

## Test plan

- [x] `tsc -p tsconfig.build.json --noEmit` passes
- [x] `validate-schema.sh` passes (4/4 schemas)
- [x] `tsc --noEmit --strict tests/*.test-d.ts` passes
- [ ] Review diff for type/schema symmetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)