### PR TITLE
ADR 031: Replace subcomponent config with nested processing.subcomponents object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SubcomponentRef` — reference to a subcomponent definition via `{ $ref: "#/subcomponents/{key}" }`
 - `AnatomyElement.instanceOf` — widened to accept `string | SubcomponentRef`
 - `Element.instanceOf` — widened to accept `string | PropBinding | SubcomponentRef`
-- `Config.processing.subcomponents` — nested object grouping subcomponent discovery settings: `scope`, `match`, and `exclude`
+- `Config.processing.subcomponents` — optional nested object grouping subcomponent discovery settings: `scope`, `match`, and `exclude`. Absence means no subcomponent detection
 - `Config.processing.subcomponents.scope` — optional enum (`NESTED` | `PAGE`) controlling where the transformer searches for subcomponents
 - `Config.processing.subcomponents.match` — required array of `{C}`/`{S}` template patterns defining which assets are subcomponents
 - `Config.processing.subcomponents.exclude` — optional array of `{C}`/`{S}` template patterns defining which matched assets to exclude
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Migration
 
 - `Config.processing.subcomponentNamePattern` → `Config.processing.subcomponents.match`: wrap the single pattern string in a one-element array
-- `Config.include.subcomponents` → removed: remove the field; subcomponents are included when `processing.subcomponents.match` is defined
+- `Config.include.subcomponents` → removed: remove the field; subcomponents are included when `processing.subcomponents` is defined with `match` patterns. Omit `processing.subcomponents` entirely to disable detection
 
 
 ## [0.14.0] - 2026-03-18

--- a/adr/031-subcomponent-search-scope.md
+++ b/adr/031-subcomponent-search-scope.md
@@ -80,9 +80,9 @@ Group subcomponent settings into a nested object inside `processing`. Remove `in
 
 ```yaml
 processing:
-  subcomponents:                                # replaces flat subcomponentNamePattern
+  subcomponents?:                               # optional; absence = no subcomponent detection
     scope?: "NESTED" | "PAGE"                   # new — defaults to NESTED
-    match:                                      # required, minItems: 1
+    match:                                      # required when subcomponents defined, minItems: 1
       - "{C} / {S}"
       - "{C} / _ / {S}"
     exclude?:                                   # optional
@@ -186,9 +186,9 @@ subcomponents:
 | `X / Text cases / Y` | matches `{C} / Text cases / {S}` in `exclude` | **excluded** |
 | `X / Docs / Intro` | no `match` hit | **ignored** (not a subcomponent) |
 
-**Resolution rules**:
+**Resolution rules** (apply identically to both anatomy-based and page-level detection):
 - An asset must match at least one `match` pattern to be considered
-- If it also matches an `exclude` pattern, the exclusion wins (explicit deny)
+- If it also matches an `exclude` pattern, the exclusion wins (explicit deny) — regardless of whether the asset was discovered via anatomy or page search
 - Assets that match neither are ignored
 
 **Pros**:
@@ -292,8 +292,8 @@ subcomponents:
 | File | Change | Bump |
 |------|--------|------|
 | `Config.ts` | Remove `processing.subcomponentNamePattern` | MAJOR |
-| `Config.ts` | Add `processing.subcomponents` object with `scope?`, `match`, `exclude?` | MAJOR |
-| `Config.ts` | Remove `include.subcomponents` (implied by `match`) | MAJOR |
+| `Config.ts` | Add optional `processing.subcomponents?` object with `scope?`, `match`, `exclude?` | MAJOR |
+| `Config.ts` | Remove `include.subcomponents` (implied by presence of `subcomponents`) | MAJOR |
 
 **Example — new shape** (`types/Config.ts`):
 ```yaml
@@ -314,9 +314,9 @@ include:
 
 # After
 processing:
-  subcomponents:                           # new nested object
+  subcomponents?:                          # optional; absence = no subcomponent detection
     scope?: "NESTED" | "PAGE"              # optional, defaults to NESTED
-    match: string[]                        # required, minItems: 1 — uses {C}/{S} template syntax
+    match: string[]                        # required when present, minItems: 1 — uses {C}/{S} template syntax
     exclude?: string[]                     # optional — uses {C}/{S} template syntax
   glyphNamePattern?: string
   codeOnlyPropsPattern?: string
@@ -335,7 +335,7 @@ include:
 | File | Change | Bump |
 |------|--------|------|
 | `component.schema.json` | Remove `subcomponentNamePattern` from `Config.processing.properties` | MAJOR |
-| `component.schema.json` | Add `subcomponents` object to `Config.processing.properties` with `scope`, `match`, `exclude` | MAJOR |
+| `component.schema.json` | Add optional `subcomponents` object to `Config.processing.properties` with `scope`, `match`, `exclude` (not in `required`) | MAJOR |
 | `component.schema.json` | Remove `subcomponents` from `Config.include.properties` and `Config.include.required` | MAJOR |
 
 **Example — new schema shape** (`schema/component.schema.json`):
@@ -366,9 +366,10 @@ subcomponents:
 
 ### Notes
 
-- `processing.subcomponentNamePattern` is removed from `required` and replaced by `processing.subcomponents` in `required`
-- `include.subcomponents` is removed from `include.required` and `include.properties` — subcomponent inclusion is now implied by the presence of `match` patterns
+- `processing.subcomponentNamePattern` is removed from `required`; `processing.subcomponents` is added as an optional property (not in `required`)
+- `include.subcomponents` is removed from `include.required` and `include.properties` — subcomponent detection is now conditional on the presence of `processing.subcomponents`; absence means no detection
 - Both `match` and `exclude` entries use `{C}` / `{S}` template syntax (Decision 3a)
+- `match` and `exclude` apply universally to both anatomy-based and page-level subcomponent detection. An asset matching both a `match` and an `exclude` pattern is excluded regardless of discovery source
 - `DEFAULT_CONFIG` must be updated:
   ```typescript
   processing: {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -814,7 +814,6 @@
             }
           },
           "required": [
-            "subcomponents",
             "variantDepth",
             "details"
           ],

--- a/tests/Config.test-d.ts
+++ b/tests/Config.test-d.ts
@@ -9,7 +9,6 @@ import { DEFAULT_CONFIG } from '../types/index.js';
 // ─── Helper: minimal valid processing + format + include ──────────────────────
 
 const minProcessing: Config['processing'] = {
-  subcomponents: { match: ['{C} / _ / {S}'] },
   variantDepth: 9999,
   details: 'LAYERED',
 };
@@ -65,11 +64,22 @@ const configWithoutScope: Config = {
   include: { variantNames: true, invalidVariants: true, invalidCombinations: false },
 };
 
+// ─── processing.subcomponents is optional ────────────────────────────────────
+
+const configWithoutSubcomponents: Config = {
+  processing: { variantDepth: 9999, details: 'LAYERED' },
+  format: minFormat,
+  include: minInclude,
+};
+
+const _subcomponentsUndefined: Config['processing']['subcomponents'] = undefined;
+
 // ─── subcomponents.scope enum values ──────────────────────────────────────────
 
-const scopeNested: Config['processing']['subcomponents']['scope'] = 'NESTED';
-const scopePage: Config['processing']['subcomponents']['scope'] = 'PAGE';
-const scopeUndefined: Config['processing']['subcomponents']['scope'] = undefined;
+type SubcomponentsScope = NonNullable<Config['processing']['subcomponents']>['scope'];
+const scopeNested: SubcomponentsScope = 'NESTED';
+const scopePage: SubcomponentsScope = 'PAGE';
+const scopeUndefined: SubcomponentsScope = undefined;
 
 // ─── subcomponents.exclude is optional ────────────────────────────────────────
 
@@ -86,7 +96,7 @@ const configWithExclude: Config = {
   include: minInclude,
 };
 
-const _excludeUndefined: Config['processing']['subcomponents']['exclude'] = undefined;
+const _excludeUndefined: NonNullable<Config['processing']['subcomponents']>['exclude'] = undefined;
 
 // ─── include no longer has subcomponents field ────────────────────────────────
 

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -8,8 +8,8 @@
  */
 export interface Config {
   processing: {
-    /** Subcomponent discovery settings: scope, match patterns, and exclusion patterns. @since 0.15.0 */
-    subcomponents: {
+    /** Subcomponent discovery settings: scope, match patterns, and exclusion patterns. Optional; absence means no subcomponent detection. @since 0.15.0 */
+    subcomponents?: {
       /** Where to search for subcomponents. NESTED = anatomy only (default); PAGE = also search the Figma page. */
       scope?: 'NESTED' | 'PAGE';
       /** Template patterns defining which assets are subcomponents. Uses {C} (component name) and {S} (subcomponent name) placeholders. */


### PR DESCRIPTION
## Summary

- **Breaking:** Removes `processing.subcomponentNamePattern` (string) and `include.subcomponents` (boolean) in favor of a single nested `processing.subcomponents` object with `scope?`, `match[]`, and `exclude?[]`
- Subcomponent detection is now opt-in by presence: define `processing.subcomponents` with `match` patterns to enable detection; omit the entire object to disable it (replaces the old `include.subcomponents` toggle)
- Adds optional `scope` enum (`NESTED` | `PAGE`) controlling where the transformer searches for subcomponents, defaulting to `NESTED`
- Updates JSON schema, TypeScript types, type-level tests, changelog with migration notes, and adds ADR 031 documenting the decision
- This is a **major breaking change** absorbed into the 0.15.0 release

## Test plan

- [ ] `npm test` passes in anova (type-level tests updated)
- [ ] Rebuild anova-transformer and verify it compiles against updated types
- [ ] Verify downstream repos (anova-kit, anova-plugin) adapt to the new config shape
- [ ] Run anova-dev-testing parity suite after transformer migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)