### PR TITLE
ADR 034: Remove variantNames, add emptyVariants, make Config.include fields optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Config.include.emptyVariants` — optional boolean to control inclusion of layered variants that contain no elements; defaults to false
+
 ### Changed
 
+- `Config.include.invalidVariants` — now optional; defaults to false when absent
+- `Config.include.invalidCombinations` — now optional; defaults to true when absent
+
 ### Removed
+
+- `Config.include.variantNames` — unused field removed from the API
+
+### Migration
+
+- `Config.include.variantNames` → removed: delete any references to this field from config construction code; regenerate cached specs to remove the field from serialized output
 
 
 ## [0.15.0] - 2026-03-25

--- a/adr/034-empty-variants.md
+++ b/adr/034-empty-variants.md
@@ -1,4 +1,4 @@
-# ADR: Make Config.include fields optional and add emptyVariants
+# ADR: Remove variantNames, add emptyVariants, make Config.include fields optional
 
 **Branch**: `034-empty-variants`
 **Created**: 2026-03-30
@@ -22,22 +22,27 @@ include: {
 }
 ```
 
-There is no `emptyVariants` field (or equivalent) for the transformer to read. Additionally, all three existing fields are required, which deviates from the broader Config pattern where most fields are optional with defaults specified in `DEFAULT_CONFIG` (e.g., `tokens?`, `inferNumberProps?`, `slotConstraints?`, `subcomponents?`, `glyphNamePattern?`).
+There is no `emptyVariants` field (or equivalent) for the transformer to read. Additionally:
 
-This creates two issues:
-1. The plugin setting cannot be mapped to the `Config` object passed to the transformer
-2. The `include` section is inconsistent with the rest of the Config structure
+1. **Missing field**: The `emptyVariants` setting cannot be mapped to the config
+2. **Dead feature**: `variantNames` is no longer used by any consumer and serves no purpose in current output
+3. **Inconsistent pattern**: All three fields are required, which deviates from the broader Config pattern where most fields are optional with defaults specified in `DEFAULT_CONFIG`
 
-This ADR addresses both by adding the missing `emptyVariants` field and making all `include` fields optional for consistency.
+This ADR addresses all three issues by:
+- Removing the unused `variantNames` field (breaking change)
+- Adding the missing `emptyVariants` field (additive)
+- Making remaining `include` fields optional for consistency (non-breaking)
 
 ---
 
 ## Decision Drivers
 
-- **Additive-only change**: Must not break existing consumers; should be MINOR version bump
+- **Remove dead code**: `variantNames` serves no purpose and should be removed to reduce API surface
+- **Accept breaking change**: Removing a field requires MAJOR version bump per Constitution III
+- **Add missing functionality**: `emptyVariants` needed to support plugin UI and variant filtering
 - **Type ↔ schema symmetry**: Both `types/Config.ts` and `schema/component.schema.json` must be updated in lockstep per Constitution I
 - **No runtime logic**: This package defines the contract only; filtering logic belongs in `anova-transformer` per Constitution II
-- **Explicit defaults**: `DEFAULT_CONFIG` must specify the default value to ensure consistent behavior across CLI and plugin per existing pattern
+- **Explicit defaults**: `DEFAULT_CONFIG` must specify default values to ensure consistent behavior
 - **Consistency with Config pattern**: Optional fields with defaults are the established norm (e.g., `tokens?`, `inferNumberProps?`, `slotConstraints?`)
 - **Internal consistency**: The `include` section should follow a uniform pattern — all fields optional with defaults
 
@@ -45,29 +50,31 @@ This ADR addresses both by adding the missing `emptyVariants` field and making a
 
 ## Options Considered
 
-### Option A: Make all `Config.include` fields optional with defaults *(Selected)*
+### Option A: Remove `variantNames`, add `emptyVariants`, make remaining fields optional *(Selected)*
 
-Add new field `emptyVariants?: boolean` and make existing fields (`variantNames`, `invalidVariants`, `invalidCombinations`) optional as well. All fields default to their current `DEFAULT_CONFIG` values when absent.
+Remove the unused `variantNames` field entirely, add new field `emptyVariants?: boolean`, and make remaining fields (`invalidVariants`, `invalidCombinations`) optional. All fields default to their current `DEFAULT_CONFIG` values when absent.
 
 **Pros**:
-- Creates consistency within the `include` section — all fields follow the same pattern
-- Follows established Config pattern of optional fields with sensible defaults (`tokens?`, `inferNumberProps?`, `slotConstraints?`, etc.)
-- Additive change — existing code continues to work without modification (MINOR bump)
+- Removes dead code — `variantNames` is not used by any consumer
+- Reduces API surface and cognitive load
+- Adds needed `emptyVariants` functionality
+- Creates consistency within the `include` section — all remaining fields follow the same optional pattern
+- Follows established Config pattern of optional fields with sensible defaults
 - Serialized configs can omit fields when using default behavior, reducing output size
-- Consumers don't need to update existing config construction code
-- Makes the intent explicit: "if not specified, use the sensible default"
+- Forces consumers to explicitly handle the breaking change, ensuring they're aware of the removal
 
 **Cons / Trade-offs**:
-- Consumers must handle both presence and absence for all include fields (but this is already the pattern for many Config fields)
-- Changes the shape of the `include` section in a broader way than just adding one field
+- Breaking change — consumers using `variantNames` must update (but since it's unused, impact should be minimal)
+- Requires MAJOR version bump
+- Consumers must remove `variantNames` from their config construction code
 
 ---
 
-### Option B: Add only `emptyVariants?` as optional, keep others required *(Rejected)*
+### Option B: Keep `variantNames` but make it optional *(Rejected)*
 
-Add new optional field `emptyVariants?: boolean` but leave `variantNames`, `invalidVariants`, and `invalidCombinations` as required.
+Make `variantNames` optional instead of removing it, treating it as deprecated.
 
-**Rejected because**: Creates inconsistency within the `include` section — some fields required, some optional. This makes the API harder to learn and understand. If we're adopting optional-with-defaults for new fields, existing fields should follow the same pattern for consistency.
+**Rejected because**: Keeping unused fields creates technical debt and API clutter. If the field serves no purpose, it should be removed rather than deprecated. A MAJOR bump is acceptable since we're already in v0.x where breaking changes are expected.
 
 ---
 
@@ -85,8 +92,10 @@ Place the field under `processing` rather than `include`, since it affects the p
 
 | File | Change | Bump |
 |------|--------|------|
-| `Config.ts` | Make `variantNames`, `invalidVariants`, `invalidCombinations` optional in `Config.include` interface | MINOR |
+| `Config.ts` | Remove `variantNames` field from `Config.include` interface | MAJOR |
+| `Config.ts` | Make `invalidVariants`, `invalidCombinations` optional in `Config.include` interface | MINOR |
 | `Config.ts` | Add new optional field `emptyVariants?: boolean` to `Config.include` interface | MINOR |
+| `Config.ts` | Remove `variantNames: false` from `DEFAULT_CONFIG.include` | MAJOR |
 | `Config.ts` | Add `emptyVariants: false` to `DEFAULT_CONFIG.include` | MINOR |
 
 **Example — new shape** (`types/Config.ts`):
@@ -101,18 +110,26 @@ include: {
 
 // After
 include: {
-  variantNames?: boolean;
+  // variantNames removed — breaking change
   invalidVariants?: boolean;
   invalidCombinations?: boolean;
-  emptyVariants?: boolean;
+  emptyVariants?: boolean;  // NEW
 }
 ```
 
-**Default values** (`DEFAULT_CONFIG` — unchanged):
+**Default values** (`DEFAULT_CONFIG`):
 
 ```typescript
+// Before
 include: {
   variantNames: false,
+  invalidVariants: false,
+  invalidCombinations: true,
+}
+
+// After
+include: {
+  // variantNames removed
   invalidVariants: false,
   invalidCombinations: true,
   emptyVariants: false,  // NEW
@@ -125,43 +142,65 @@ include: {
 
 | File | Change | Bump |
 |------|--------|------|
-| `component.schema.json` | Remove `variantNames`, `invalidVariants`, `invalidCombinations` from `#/definitions/Config/properties/include/required` array | MINOR |
+| `component.schema.json` | Remove `variantNames` property from `#/definitions/Config/properties/include/properties` | MAJOR |
+| `component.schema.json` | Remove all fields from `#/definitions/Config/properties/include/required` array (make remaining fields optional) | MINOR |
 | `component.schema.json` | Add optional `emptyVariants` property to `#/definitions/Config/properties/include/properties` | MINOR |
 
 **Example — new shape** (`schema/component.schema.json`):
 
 ```json
+// Before
 "include": {
   "type": "object",
   "properties": {
     "variantNames": {
-      "type": "boolean",
-      "description": "Include variant names"
+      "type": "boolean"
     },
     "invalidVariants": {
+      "type": "boolean"
+    },
+    "invalidCombinations": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "variantNames",
+    "invalidVariants",
+    "invalidCombinations"
+  ],
+  "additionalProperties": false
+}
+
+// After
+"include": {
+  "type": "object",
+  "properties": {
+    // "variantNames" removed — breaking change
+    "invalidVariants": {
       "type": "boolean",
-      "description": "Include invalid variants"
+      "description": "Include invalid variants. Defaults to false when absent."
     },
     "invalidCombinations": {
       "type": "boolean",
-      "description": "Include invalid combinations"
+      "description": "Include invalid combinations. Defaults to true when absent."
     },
     "emptyVariants": {
       "type": "boolean",
       "description": "When false, exclude layered variants that contain no elements from output. When true, include all variants regardless of element presence. Defaults to false when absent."
     }
   },
-  "required": [
-    // All fields now optional — empty array or remove property
-  ],
+  "required": [],  // All fields now optional
   "additionalProperties": false
 }
 ```
 
 ### Notes
 
-- **Scope expansion**: This ADR initially focused on adding `emptyVariants`, but was expanded to make all `include` fields optional for consistency with the broader Config pattern
-- All `include` fields now follow the same pattern: optional in the type/schema, explicit defaults in `DEFAULT_CONFIG`
+- **Scope expansion**: This ADR initially focused on adding `emptyVariants`, but was expanded to:
+  1. Remove the unused `variantNames` field (breaking change)
+  2. Make remaining `include` fields optional for consistency with the broader Config pattern
+- `variantNames` removal rationale: The field is not used by any consumer and serves no purpose in current output. Removing it reduces API surface and eliminates dead code.
+- All remaining `include` fields follow the same pattern: optional in the type/schema, explicit defaults in `DEFAULT_CONFIG`
 - The field name `emptyVariants` follows the "include" semantics: `false` = exclude empty variants from output, `true` = include them
 - "Empty variant" is defined as: a layered variant (when `processing.details = 'LAYERED'`) that contains no elements in its diff from the default variant
 - The filtering logic implementation is deferred to `anova-transformer` (separate issue)
@@ -172,11 +211,12 @@ include: {
 ## Type ↔ Schema Impact
 
 - **Symmetric**: Yes
-- **Parity check**: 
-  - TypeScript: `Config.include.emptyVariants: boolean`
-  - JSON Schema: `#/definitions/Config/properties/include/properties/emptyVariants` with `type: "boolean"`
-  - Both add the field to their respective required lists
+- **Parity check**:
+  - `variantNames` removed from both TypeScript type and JSON schema
+  - `emptyVariants` added to both: TypeScript as optional field, JSON schema as optional property (not in `required` array)
+  - `invalidVariants` and `invalidCombinations` changed to optional in both TypeScript type and JSON schema
   - Both maintain `additionalProperties: false` to prevent drift
+  - Field count: 3 → 3 (removed 1, added 1, kept 2)
 
 ---
 
@@ -184,34 +224,58 @@ include: {
 
 | Consumer | Impact | Action required |
 |----------|--------|-----------------|
-| `anova-kit` | CLI must update to pass new config field from settings | Add default value handling; expose flag in CLI if applicable |
-| `anova-transformer` | Must implement filtering logic to read and act on the flag | Separate issue: filter out empty variants when `config.include.emptyVariants === false` |
-| `anova-plugin` | Must wire `DATA_EMPTY_VARIANTS` UI setting to the config field | Separate issue: map plugin setting to `config.include.emptyVariants` in `settingsToModelConfig()` |
+| `anova-kit` | **Breaking**: Must remove `variantNames` from CLI; must add `emptyVariants` support | Remove `variantNames` references; add `emptyVariants` flag to CLI options |
+| `anova-transformer` | **Breaking**: Must remove `variantNames` handling; must implement `emptyVariants` filtering | Remove dead `variantNames` code; implement empty variant filtering logic |
+| `anova-plugin` | **Breaking**: Must remove `variantNames` from config mapping; must wire `emptyVariants` to UI | Remove `variantNames` from `settingsToModelConfig()`; map `DATA_EMPTY_VARIANTS` to `config.include.emptyVariants` |
 
 ---
 
 ## Semver Decision
 
-**Version bump**: `[CURRENT] → [NEXT MINOR]` (`MINOR`)
+**Version bump**: `[CURRENT] → [NEXT MAJOR]` (`MAJOR`)
 
-**Justification**: Per Constitution III, adding a new optional field to an existing type is a non-breaking additive change and requires a MINOR version bump. The field is optional in the sense that existing code will continue to work (the transformer ignores unknown fields), but the schema marks it as required to ensure explicit intent in serialized configs via `DEFAULT_CONFIG`.
+**Justification**: Per Constitution III, removing a field from an exported type is a breaking change and requires a MAJOR version bump.
 
-More precisely:
-- Adding `emptyVariants` to the TypeScript type is additive (MINOR)
-- Adding it to the schema with a default value in `DEFAULT_CONFIG` ensures backward compatibility
-- All downstream consumers will receive the new field via `DEFAULT_CONFIG` without code changes
-- Consumers that construct `Config` objects manually must add the field, but this is a compilation error (caught at build time), not a runtime break
+Breaking changes:
+- Removing `variantNames` from the TypeScript type breaks any consumer code that references it
+- Removing `variantNames` from the schema breaks validation for any serialized specs that include it
+
+Non-breaking changes (would be MINOR on their own):
+- Adding `emptyVariants` as optional field is additive
+- Making `invalidVariants` and `invalidCombinations` optional maintains backward compatibility
+
+Impact analysis:
+- Consumers that reference `config.include.variantNames` will get TypeScript compilation errors (caught at build time)
+- Consumers that construct `Config` objects with `variantNames` will get TypeScript errors
+- Existing serialized specs with `variantNames` will fail schema validation until regenerated
+- Since `variantNames` was not used in practice, real-world impact should be minimal
 
 ---
 
 ## Consequences
 
-- The entire `Config.include` section now follows a consistent pattern: all fields optional with explicit defaults in `DEFAULT_CONFIG`
-- Serialized configs can omit `include` fields when using default values, reducing output size
-- The `Config` contract now supports signaling whether to include or exclude empty variants in output
-- The transformer can implement filtering logic for layered variants without elements once this ADR is accepted
-- The plugin can wire its existing UI setting to the config field, making the checkbox functional
-- Consumers validating against `schema/component.schema.json` must update to the new version to accept specs with optional `include` fields
-- Consumers constructing `Config` objects can now omit any `include` field and rely on `DEFAULT_CONFIG` merging or explicit defaults
-- Existing code that provides all `include` fields continues to work without modification (backward compatible)
-- Establishes `Config.include` as a clean example of the optional-with-defaults pattern for future Config additions
+### Positive
+
+- **Dead code removed**: `variantNames` eliminated from the API, reducing surface area and cognitive load
+- **Consistent pattern**: All remaining `Config.include` fields follow the optional-with-defaults pattern
+- **New functionality**: `emptyVariants` enables filtering of layered variants without elements
+- **Smaller output**: Serialized configs can omit `include` fields when using default values
+- **Clear example**: `Config.include` demonstrates the optional-with-defaults pattern for future Config additions
+
+### Breaking changes
+
+- **Compilation errors**: Consumers referencing `config.include.variantNames` will get TypeScript errors (caught at build time)
+- **Schema validation**: Existing serialized specs containing `variantNames` will fail validation until regenerated
+- **Code updates required**: Consumers must remove `variantNames` from config construction code
+
+### Downstream work
+
+- `anova-transformer`: Must remove any `variantNames` handling logic and implement `emptyVariants` filtering
+- `anova-plugin`: Must remove `variantNames` from config mapping and wire `emptyVariants` to UI
+- `anova-kit`: Must remove `variantNames` from CLI options and handle `emptyVariants`
+
+### Migration path
+
+- Consumers should search codebase for `variantNames` references and remove them
+- Regenerate any cached/serialized specs to remove `variantNames` and conform to new schema
+- No runtime fallback needed since field was unused

--- a/adr/034-empty-variants.md
+++ b/adr/034-empty-variants.md
@@ -1,4 +1,4 @@
-# ADR: Add Config.include.emptyVariants to support filtering layered variants without elements
+# ADR: Make Config.include fields optional and add emptyVariants
 
 **Branch**: `034-empty-variants`
 **Created**: 2026-03-30
@@ -12,7 +12,7 @@
 
 The `anova-plugin` UI exposes an "Include layered variants without elements" checkbox setting (`DATA_EMPTY_VARIANTS` in `src/UI/App/Settings/VariantsChildren.ts`), but toggling it has no effect on the transformer output. The setting is purely cosmetic — it persists in localStorage but is never passed through to the transformer pipeline.
 
-Currently, the `Config.include` type in `types/Config.ts` defines three boolean fields:
+Currently, the `Config.include` type in `types/Config.ts` defines three required boolean fields:
 
 ```typescript
 include: {
@@ -22,14 +22,13 @@ include: {
 }
 ```
 
-There is no `emptyVariants` field (or equivalent) for the transformer to read. This means:
+There is no `emptyVariants` field (or equivalent) for the transformer to read. Additionally, all three existing fields are required, which deviates from the broader Config pattern where most fields are optional with defaults specified in `DEFAULT_CONFIG` (e.g., `tokens?`, `inferNumberProps?`, `slotConstraints?`, `subcomponents?`, `glyphNamePattern?`).
+
+This creates two issues:
 1. The plugin setting cannot be mapped to the `Config` object passed to the transformer
-2. The transformer has no signal to filter out layered variants that contain no elements
-3. All valid variants are always included in output regardless of element presence
+2. The `include` section is inconsistent with the rest of the Config structure
 
-When `processing.details` is set to `'LAYERED'`, the transformer computes diffs between each variant and the default variant. In some cases, a layered variant may have no elements — its diff is structurally present but semantically empty. Consumers may wish to exclude these variants from the output to reduce noise.
-
-This ADR addresses the missing contract field that would enable downstream filtering behavior.
+This ADR addresses both by adding the missing `emptyVariants` field and making all `include` fields optional for consistency.
 
 ---
 
@@ -39,33 +38,36 @@ This ADR addresses the missing contract field that would enable downstream filte
 - **Type ↔ schema symmetry**: Both `types/Config.ts` and `schema/component.schema.json` must be updated in lockstep per Constitution I
 - **No runtime logic**: This package defines the contract only; filtering logic belongs in `anova-transformer` per Constitution II
 - **Explicit defaults**: `DEFAULT_CONFIG` must specify the default value to ensure consistent behavior across CLI and plugin per existing pattern
-- **Consistency with existing include fields**: Should follow the same boolean flag pattern as `variantNames`, `invalidVariants`, and `invalidCombinations`
+- **Consistency with Config pattern**: Optional fields with defaults are the established norm (e.g., `tokens?`, `inferNumberProps?`, `slotConstraints?`)
+- **Internal consistency**: The `include` section should follow a uniform pattern — all fields optional with defaults
 
 ---
 
 ## Options Considered
 
-### Option A: Add `emptyVariants: boolean` to `Config.include` *(Selected)*
+### Option A: Make all `Config.include` fields optional with defaults *(Selected)*
 
-Add a new optional boolean field `emptyVariants` to the `Config.include` type and schema. When `false` (default), all variants are included in output regardless of element presence. When `true`, layered variants without elements are excluded from output.
+Add new field `emptyVariants?: boolean` and make existing fields (`variantNames`, `invalidVariants`, `invalidCombinations`) optional as well. All fields default to their current `DEFAULT_CONFIG` values when absent.
 
 **Pros**:
-- Follows existing pattern of other `include` fields (boolean flags that control output filtering)
+- Creates consistency within the `include` section — all fields follow the same pattern
+- Follows established Config pattern of optional fields with sensible defaults (`tokens?`, `inferNumberProps?`, `slotConstraints?`, etc.)
 - Additive change — existing code continues to work without modification (MINOR bump)
-- Provides clear signal to transformer for filtering behavior
-- Name aligns with plugin UI terminology and existing `invalidVariants` precedent
+- Serialized configs can omit fields when using default behavior, reducing output size
+- Consumers don't need to update existing config construction code
+- Makes the intent explicit: "if not specified, use the sensible default"
 
 **Cons / Trade-offs**:
-- Field name could be interpreted two ways: "include empty variants" (keep them) vs "filter empty variants" (remove them). We follow the "include" semantics: `true` = include them, `false` = exclude them.
-- Adds another required field to the `include` object in schema (must be present in all serialized configs)
+- Consumers must handle both presence and absence for all include fields (but this is already the pattern for many Config fields)
+- Changes the shape of the `include` section in a broader way than just adding one field
 
 ---
 
-### Option B: Add `Config.include.emptyVariants` as optional field *(Rejected)*
+### Option B: Add only `emptyVariants?` as optional, keep others required *(Rejected)*
 
-Make the field optional in both type and schema, defaulting to `true` (include empty variants) when absent.
+Add new optional field `emptyVariants?: boolean` but leave `variantNames`, `invalidVariants`, and `invalidCombinations` as required.
 
-**Rejected because**: Making the field optional adds ambiguity — consumers must handle both presence and absence. The existing pattern in `Config.include` is that all fields are required with explicit defaults in `DEFAULT_CONFIG`. Deviating from this pattern increases maintenance burden and breaks symmetry.
+**Rejected because**: Creates inconsistency within the `include` section — some fields required, some optional. This makes the API harder to learn and understand. If we're adopting optional-with-defaults for new fields, existing fields should follow the same pattern for consistency.
 
 ---
 
@@ -83,7 +85,8 @@ Place the field under `processing` rather than `include`, since it affects the p
 
 | File | Change | Bump |
 |------|--------|------|
-| `Config.ts` | Add optional field `emptyVariants: boolean` to `Config.include` interface | MINOR |
+| `Config.ts` | Make `variantNames`, `invalidVariants`, `invalidCombinations` optional in `Config.include` interface | MINOR |
+| `Config.ts` | Add new optional field `emptyVariants?: boolean` to `Config.include` interface | MINOR |
 | `Config.ts` | Add `emptyVariants: false` to `DEFAULT_CONFIG.include` | MINOR |
 
 **Example — new shape** (`types/Config.ts`):
@@ -98,32 +101,32 @@ include: {
 
 // After
 include: {
-  variantNames: boolean;
-  invalidVariants: boolean;
-  invalidCombinations: boolean;
-  emptyVariants: boolean;
+  variantNames?: boolean;
+  invalidVariants?: boolean;
+  invalidCombinations?: boolean;
+  emptyVariants?: boolean;
 }
 ```
 
-**Default value** (`DEFAULT_CONFIG`):
+**Default values** (`DEFAULT_CONFIG` — unchanged):
 
 ```typescript
 include: {
   variantNames: false,
   invalidVariants: false,
   invalidCombinations: true,
-  emptyVariants: false,  // NEW: exclude empty variants by default
+  emptyVariants: false,  // NEW
 }
 ```
 
-**Rationale for default value**: Setting `emptyVariants: false` (exclude empty variants) aligns with the principle of minimal output — consumers typically want only semantically meaningful variants. Users can opt in to including empty variants when debugging or analyzing variant coverage. This matches the plugin's current default behavior.
+**Rationale for `emptyVariants` default**: Setting `emptyVariants: false` (exclude empty variants) aligns with the principle of minimal output — consumers typically want only semantically meaningful variants. Users can opt in to including empty variants when debugging or analyzing variant coverage. This matches the plugin's current default behavior.
 
 ### Schema changes (`schema/`)
 
 | File | Change | Bump |
 |------|--------|------|
-| `component.schema.json` | Add `emptyVariants` property to `#/definitions/Config/properties/include/properties` | MINOR |
-| `component.schema.json` | Add `emptyVariants` to `#/definitions/Config/properties/include/required` array | MINOR |
+| `component.schema.json` | Remove `variantNames`, `invalidVariants`, `invalidCombinations` from `#/definitions/Config/properties/include/required` array | MINOR |
+| `component.schema.json` | Add optional `emptyVariants` property to `#/definitions/Config/properties/include/properties` | MINOR |
 
 **Example — new shape** (`schema/component.schema.json`):
 
@@ -132,24 +135,24 @@ include: {
   "type": "object",
   "properties": {
     "variantNames": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Include variant names"
     },
     "invalidVariants": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Include invalid variants"
     },
     "invalidCombinations": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Include invalid combinations"
     },
     "emptyVariants": {
       "type": "boolean",
-      "description": "When false, exclude layered variants that contain no elements from output. When true, include all variants regardless of element presence."
+      "description": "When false, exclude layered variants that contain no elements from output. When true, include all variants regardless of element presence. Defaults to false when absent."
     }
   },
   "required": [
-    "variantNames",
-    "invalidVariants",
-    "invalidCombinations",
-    "emptyVariants"
+    // All fields now optional — empty array or remove property
   ],
   "additionalProperties": false
 }
@@ -157,6 +160,8 @@ include: {
 
 ### Notes
 
+- **Scope expansion**: This ADR initially focused on adding `emptyVariants`, but was expanded to make all `include` fields optional for consistency with the broader Config pattern
+- All `include` fields now follow the same pattern: optional in the type/schema, explicit defaults in `DEFAULT_CONFIG`
 - The field name `emptyVariants` follows the "include" semantics: `false` = exclude empty variants from output, `true` = include them
 - "Empty variant" is defined as: a layered variant (when `processing.details = 'LAYERED'`) that contains no elements in its diff from the default variant
 - The filtering logic implementation is deferred to `anova-transformer` (separate issue)
@@ -201,9 +206,12 @@ More precisely:
 
 ## Consequences
 
+- The entire `Config.include` section now follows a consistent pattern: all fields optional with explicit defaults in `DEFAULT_CONFIG`
+- Serialized configs can omit `include` fields when using default values, reducing output size
 - The `Config` contract now supports signaling whether to include or exclude empty variants in output
 - The transformer can implement filtering logic for layered variants without elements once this ADR is accepted
 - The plugin can wire its existing UI setting to the config field, making the checkbox functional
-- Consumers validating against `schema/component.schema.json` must update to the new version to accept specs with the `emptyVariants` field
-- Serialized specs will include `config.include.emptyVariants: false` by default, explicitly documenting the filtering behavior
-- Adding this field establishes a precedent for other "include" flags that control output filtering based on variant characteristics
+- Consumers validating against `schema/component.schema.json` must update to the new version to accept specs with optional `include` fields
+- Consumers constructing `Config` objects can now omit any `include` field and rely on `DEFAULT_CONFIG` merging or explicit defaults
+- Existing code that provides all `include` fields continues to work without modification (backward compatible)
+- Establishes `Config.include` as a clean example of the optional-with-defaults pattern for future Config additions

--- a/adr/034-empty-variants.md
+++ b/adr/034-empty-variants.md
@@ -1,0 +1,209 @@
+# ADR: Add Config.include.emptyVariants to support filtering layered variants without elements
+
+**Branch**: `034-empty-variants`
+**Created**: 2026-03-30
+**Status**: DRAFT
+**Deciders**: nathanacurtis (author)
+**Supersedes**: *(none)*
+
+---
+
+## Context
+
+The `anova-plugin` UI exposes an "Include layered variants without elements" checkbox setting (`DATA_EMPTY_VARIANTS` in `src/UI/App/Settings/VariantsChildren.ts`), but toggling it has no effect on the transformer output. The setting is purely cosmetic — it persists in localStorage but is never passed through to the transformer pipeline.
+
+Currently, the `Config.include` type in `types/Config.ts` defines three boolean fields:
+
+```typescript
+include: {
+  variantNames: boolean;
+  invalidVariants: boolean;
+  invalidCombinations: boolean;
+}
+```
+
+There is no `emptyVariants` field (or equivalent) for the transformer to read. This means:
+1. The plugin setting cannot be mapped to the `Config` object passed to the transformer
+2. The transformer has no signal to filter out layered variants that contain no elements
+3. All valid variants are always included in output regardless of element presence
+
+When `processing.details` is set to `'LAYERED'`, the transformer computes diffs between each variant and the default variant. In some cases, a layered variant may have no elements — its diff is structurally present but semantically empty. Consumers may wish to exclude these variants from the output to reduce noise.
+
+This ADR addresses the missing contract field that would enable downstream filtering behavior.
+
+---
+
+## Decision Drivers
+
+- **Additive-only change**: Must not break existing consumers; should be MINOR version bump
+- **Type ↔ schema symmetry**: Both `types/Config.ts` and `schema/component.schema.json` must be updated in lockstep per Constitution I
+- **No runtime logic**: This package defines the contract only; filtering logic belongs in `anova-transformer` per Constitution II
+- **Explicit defaults**: `DEFAULT_CONFIG` must specify the default value to ensure consistent behavior across CLI and plugin per existing pattern
+- **Consistency with existing include fields**: Should follow the same boolean flag pattern as `variantNames`, `invalidVariants`, and `invalidCombinations`
+
+---
+
+## Options Considered
+
+### Option A: Add `emptyVariants: boolean` to `Config.include` *(Selected)*
+
+Add a new optional boolean field `emptyVariants` to the `Config.include` type and schema. When `false` (default), all variants are included in output regardless of element presence. When `true`, layered variants without elements are excluded from output.
+
+**Pros**:
+- Follows existing pattern of other `include` fields (boolean flags that control output filtering)
+- Additive change — existing code continues to work without modification (MINOR bump)
+- Provides clear signal to transformer for filtering behavior
+- Name aligns with plugin UI terminology and existing `invalidVariants` precedent
+
+**Cons / Trade-offs**:
+- Field name could be interpreted two ways: "include empty variants" (keep them) vs "filter empty variants" (remove them). We follow the "include" semantics: `true` = include them, `false` = exclude them.
+- Adds another required field to the `include` object in schema (must be present in all serialized configs)
+
+---
+
+### Option B: Add `Config.include.emptyVariants` as optional field *(Rejected)*
+
+Make the field optional in both type and schema, defaulting to `true` (include empty variants) when absent.
+
+**Rejected because**: Making the field optional adds ambiguity — consumers must handle both presence and absence. The existing pattern in `Config.include` is that all fields are required with explicit defaults in `DEFAULT_CONFIG`. Deviating from this pattern increases maintenance burden and breaks symmetry.
+
+---
+
+### Option C: Add `Config.processing.filterEmptyVariants: boolean` *(Rejected)*
+
+Place the field under `processing` rather than `include`, since it affects the processing pipeline.
+
+**Rejected because**: The field controls *what to include in output*, not *how to process input*. It parallels `invalidVariants` and `invalidCombinations`, both of which live in `include`. Separating conceptually related fields undermines discoverability and consistency.
+
+---
+
+## Decision
+
+### Type changes (`types/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `Config.ts` | Add optional field `emptyVariants: boolean` to `Config.include` interface | MINOR |
+| `Config.ts` | Add `emptyVariants: false` to `DEFAULT_CONFIG.include` | MINOR |
+
+**Example — new shape** (`types/Config.ts`):
+
+```typescript
+// Before
+include: {
+  variantNames: boolean;
+  invalidVariants: boolean;
+  invalidCombinations: boolean;
+}
+
+// After
+include: {
+  variantNames: boolean;
+  invalidVariants: boolean;
+  invalidCombinations: boolean;
+  emptyVariants: boolean;
+}
+```
+
+**Default value** (`DEFAULT_CONFIG`):
+
+```typescript
+include: {
+  variantNames: false,
+  invalidVariants: false,
+  invalidCombinations: true,
+  emptyVariants: false,  // NEW: exclude empty variants by default
+}
+```
+
+**Rationale for default value**: Setting `emptyVariants: false` (exclude empty variants) aligns with the principle of minimal output — consumers typically want only semantically meaningful variants. Users can opt in to including empty variants when debugging or analyzing variant coverage. This matches the plugin's current default behavior.
+
+### Schema changes (`schema/`)
+
+| File | Change | Bump |
+|------|--------|------|
+| `component.schema.json` | Add `emptyVariants` property to `#/definitions/Config/properties/include/properties` | MINOR |
+| `component.schema.json` | Add `emptyVariants` to `#/definitions/Config/properties/include/required` array | MINOR |
+
+**Example — new shape** (`schema/component.schema.json`):
+
+```json
+"include": {
+  "type": "object",
+  "properties": {
+    "variantNames": {
+      "type": "boolean"
+    },
+    "invalidVariants": {
+      "type": "boolean"
+    },
+    "invalidCombinations": {
+      "type": "boolean"
+    },
+    "emptyVariants": {
+      "type": "boolean",
+      "description": "When false, exclude layered variants that contain no elements from output. When true, include all variants regardless of element presence."
+    }
+  },
+  "required": [
+    "variantNames",
+    "invalidVariants",
+    "invalidCombinations",
+    "emptyVariants"
+  ],
+  "additionalProperties": false
+}
+```
+
+### Notes
+
+- The field name `emptyVariants` follows the "include" semantics: `false` = exclude empty variants from output, `true` = include them
+- "Empty variant" is defined as: a layered variant (when `processing.details = 'LAYERED'`) that contains no elements in its diff from the default variant
+- The filtering logic implementation is deferred to `anova-transformer` (separate issue)
+- The plugin UI mapping is deferred to `anova-plugin` (separate issue)
+
+---
+
+## Type ↔ Schema Impact
+
+- **Symmetric**: Yes
+- **Parity check**: 
+  - TypeScript: `Config.include.emptyVariants: boolean`
+  - JSON Schema: `#/definitions/Config/properties/include/properties/emptyVariants` with `type: "boolean"`
+  - Both add the field to their respective required lists
+  - Both maintain `additionalProperties: false` to prevent drift
+
+---
+
+## Downstream Impact
+
+| Consumer | Impact | Action required |
+|----------|--------|-----------------|
+| `anova-kit` | CLI must update to pass new config field from settings | Add default value handling; expose flag in CLI if applicable |
+| `anova-transformer` | Must implement filtering logic to read and act on the flag | Separate issue: filter out empty variants when `config.include.emptyVariants === false` |
+| `anova-plugin` | Must wire `DATA_EMPTY_VARIANTS` UI setting to the config field | Separate issue: map plugin setting to `config.include.emptyVariants` in `settingsToModelConfig()` |
+
+---
+
+## Semver Decision
+
+**Version bump**: `[CURRENT] → [NEXT MINOR]` (`MINOR`)
+
+**Justification**: Per Constitution III, adding a new optional field to an existing type is a non-breaking additive change and requires a MINOR version bump. The field is optional in the sense that existing code will continue to work (the transformer ignores unknown fields), but the schema marks it as required to ensure explicit intent in serialized configs via `DEFAULT_CONFIG`.
+
+More precisely:
+- Adding `emptyVariants` to the TypeScript type is additive (MINOR)
+- Adding it to the schema with a default value in `DEFAULT_CONFIG` ensures backward compatibility
+- All downstream consumers will receive the new field via `DEFAULT_CONFIG` without code changes
+- Consumers that construct `Config` objects manually must add the field, but this is a compilation error (caught at build time), not a runtime break
+
+---
+
+## Consequences
+
+- The `Config` contract now supports signaling whether to include or exclude empty variants in output
+- The transformer can implement filtering logic for layered variants without elements once this ADR is accepted
+- The plugin can wire its existing UI setting to the config field, making the checkbox functional
+- Consumers validating against `schema/component.schema.json` must update to the new version to accept specs with the `emptyVariants` field
+- Serialized specs will include `config.include.emptyVariants: false` by default, explicitly documenting the filtering behavior
+- Adding this field establishes a precedent for other "include" flags that control output filtering based on variant characteristics

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 034 | Add Config.include.emptyVariants to support filtering layered variants without elements |  |
+| 034 | Make Config.include fields optional and add emptyVariants | Make all `include` fields optional for consistency; add `emptyVariants` to filter layered variants without elements |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
 | 024 | Component Extends Relationship | Add `extends` field to express base/derived component relationships and prop/variant inheritance _(branch)_ |
 | 022 | Add Nullable Support to SlotProp | Fix type-schema drift: add `nullable?: boolean` and widen `default` to `string \| null` on SlotProp |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,7 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
-| 034 | Make Config.include fields optional and add emptyVariants | Make all `include` fields optional for consistency; add `emptyVariants` to filter layered variants without elements |
+| 034 | Remove variantNames, add emptyVariants, make Config.include fields optional | Remove unused `variantNames` (breaking); add `emptyVariants` for filtering; make remaining fields optional |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
 | 024 | Component Extends Relationship | Add `extends` field to express base/derived component relationships and prop/variant inheritance _(branch)_ |
 | 022 | Add Nullable Support to SlotProp | Fix type-schema drift: add `nullable?: boolean` and widen `default` to `string \| null` on SlotProp |

--- a/adr/INDEX.md
+++ b/adr/INDEX.md
@@ -4,6 +4,7 @@
 
 | # | Title | Highlights |
 |---|-------|------------|
+| 034 | Add Config.include.emptyVariants to support filtering layered variants without elements |  |
 | 025 | Flowing Content into a Nested Instance's Slot | Model parent components that flow defined content into a nested child instance's slot _(branch)_ |
 | 024 | Component Extends Relationship | Add `extends` field to express base/derived component relationships and prop/variant inheritance _(branch)_ |
 | 022 | Add Nullable Support to SlotProp | Fix type-schema drift: add `nullable?: boolean` and widen `default` to `string \| null` on SlotProp |

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -871,21 +871,20 @@
         "include": {
           "type": "object",
           "properties": {
-            "variantNames": {
-              "type": "boolean"
-            },
             "invalidVariants": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Include invalid variants. Optional; defaults to false."
             },
             "invalidCombinations": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Include invalid combinations. Optional; defaults to true."
+            },
+            "emptyVariants": {
+              "type": "boolean",
+              "description": "Include layered variants that contain no elements. When false (default), exclude empty variants from output. When true, include all variants regardless of element presence. Optional; defaults to false."
             }
           },
-          "required": [
-            "variantNames",
-            "invalidVariants",
-            "invalidCombinations"
-          ],
+          "required": [],
           "additionalProperties": false
         }
       },

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -41,12 +41,12 @@ export interface Config {
     tokens?: 'TOKEN' | 'TOKEN_NAME' | 'TOKEN_FIGMA_EXTENSIONS' | 'FIGMA_NAME' | 'CUSTOM';
   };
   include: {
-    /** Include variant names */
-    variantNames: boolean;
-    /** Include invalid variants */
-    invalidVariants: boolean;
-    /** Include invalid combinations */
-    invalidCombinations: boolean;
+    /** Include invalid variants. Optional; defaults to false. */
+    invalidVariants?: boolean;
+    /** Include invalid combinations. Optional; defaults to true. */
+    invalidCombinations?: boolean;
+    /** Include layered variants that contain no elements. When false (default), exclude empty variants from output. When true, include all variants regardless of element presence. Optional; defaults to false. @since 1.0.0 */
+    emptyVariants?: boolean;
   };
 }
 
@@ -62,9 +62,9 @@ export interface Config {
  * - format.keys: SAFE prevents corruption of special characters while maintaining readability
  * - format.layout: LAYOUT provides tree structure with layout properties
  * - format.tokens: TOKEN provides platform-neutral token references with $token path and $type
- * - include.variantNames: false reduces output size (names can be reconstructed from configuration)
  * - include.invalidVariants: false excludes variants that can't be instantiated
  * - include.invalidCombinations: true helps designers identify property conflicts
+ * - include.emptyVariants: false reduces output size by excluding semantically empty layered variants
  */
 export const DEFAULT_CONFIG: Config = {
   processing: {
@@ -81,8 +81,8 @@ export const DEFAULT_CONFIG: Config = {
     tokens: 'TOKEN',
   },
   include: {
-    variantNames: false,
     invalidVariants: false,
     invalidCombinations: true,
+    emptyVariants: false,
   },
 };


### PR DESCRIPTION
Implements ADR 034:

**Breaking change**: Removes unused `Config.include.variantNames` field
**Added**: `Config.include.emptyVariants` optional field for filtering empty layered variants
**Changed**: Made `invalidVariants` and `invalidCombinations` optional for consistency

All constitution gates passed ✅

Closes #83